### PR TITLE
Add "Custom CI Artifacts" workflow to build a custom image (#2)

### DIFF
--- a/.github/workflows/custom-ci-artifacts.yml
+++ b/.github/workflows/custom-ci-artifacts.yml
@@ -1,0 +1,133 @@
+# This GitHub Actions workflow customizes server-ci-artifacts.yml.
+# The differences from server-ci-artifacts.yml are as follows:
+# - It uploads container images to Google Cloud Artifact Registry instead of Docker Hub.
+# - It does not upload build artifacts to S3.
+# - It is triggered by pushes to Git tags that start with 'v'.
+name: Custom Ci Artifacts
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build'
+        required: true
+        default: 'main'
+      tag:
+        description: 'Tag to build'
+        required: false
+        default: ''
+
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - name: Checkout mattermost project
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.branch || inputs.tag) || github.ref }}
+
+      - name: Calculate Golang Version
+        id: go
+        run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: ${{ steps.go.outputs.GO_VERSION }}
+          cache-dependency-path: |
+            server/go.sum
+            server/public/go.sum
+
+      - name: ci/setup-node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        id: setup_node
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: "webapp/package-lock.json"
+
+      - name: Run setup-go-work
+        run: make setup-go-work
+
+      - name: Build
+        run: |
+          make config-reset
+          make build-cmd BUILD_NUMBER='${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}'
+          make package BUILD_NUMBER='${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}'
+
+      # In server-ci-artifacts.yml, this step uploads the artifacts to S3.
+      # Here, we place the artifacts in a directory that will be used by the next job.
+      - name: Upload Mattermost Package
+        uses: actions/upload-artifact@v4 # v4.0.0
+        with:
+          name: server-build-artifact
+          path: server/dist/mattermost-team-linux-amd64.tar.gz
+
+  build-and-push-image:
+    needs: build-artifacts
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - name: Checkout mattermost project
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && (inputs.tag || inputs.branch) || github.ref }}
+
+      - name: Download Mattermost Package
+        uses: actions/download-artifact@v4
+        with:
+          name: server-build-artifact
+          path: server/build
+
+      - name: Setup Google Cloud Auth
+        id: auth
+        uses: "google-github-actions/auth@v2"
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set Docker tags
+        id: docker_meta
+        run: |
+          IMAGE_NAME="${{ secrets.GAR_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GAR_REPOSITORY_NAME }}/${{ secrets.GAR_IMAGE_NAME }}"
+          DOCKER_TAG_NAME=""
+
+          # Priority order for determining the Docker tag name:
+          # 1. If a Git tag is pushed (e.g., v1.2.3)
+          # 2. If the 'tag' input is provided on workflow_dispatch
+          # 3. Otherwise (use the commit hash)
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "Triggered by tag push. Using git tag: ${{ github.ref_name }}"
+            DOCKER_TAG_NAME="${{ github.ref_name }}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.tag }}" ]]; then
+            echo "Triggered by workflow_dispatch with tag. Using input tag: ${{ inputs.tag }}"
+            DOCKER_TAG_NAME="${{ inputs.tag }}"
+          else
+            echo "Triggered by ${{ github.event_name }}. Using commit SHA."
+            DOCKER_TAG_NAME="${{ github.sha }}"
+          fi
+
+          TAGS="-t ${IMAGE_NAME}:${DOCKER_TAG_NAME} -t ${IMAGE_NAME}:latest"
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "Generated tags for docker build: ${TAGS}"
+
+      - name: Build and push Docker image
+        run: |
+          gcloud auth configure-docker ${{ secrets.GAR_LOCATION }}-docker.pkg.dev --quiet
+          docker buildx build \
+            --platform linux/amd64 \
+            --no-cache \
+            --push \
+            --build-arg MM_CUSTOM_PACKAGE=mattermost-team-linux-amd64.tar.gz \
+            ${{ steps.docker_meta.outputs.tags }} \
+            server/build

--- a/server/build/Dockerfile
+++ b/server/build/Dockerfile
@@ -10,6 +10,10 @@ ARG PGID=2000
 # i.e. https://releases.mattermost.com/9.7.1/mattermost-9.7.1-linux-amd64.tar.gz
 ARG MM_PACKAGE="https://latest.mattermost.com/mattermost-enterprise-linux"
 
+# Note: In the original implementation, it downloads the uploaded artifacts. In the customized version, it uses local artifacts instead.
+ARG MM_CUSTOM_PACKAGE="mattermost-team-linux-amd64.tar.gz"
+COPY ${MM_CUSTOM_PACKAGE} /tmp/app_package.tar.gz
+
 # Install needed packages and indirect dependencies
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -28,7 +32,9 @@ RUN apt-get update \
 RUN mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
   && groupadd --gid ${PGID} mattermost \
   && useradd --uid ${PUID} --gid ${PGID} --comment "" --home-dir /mattermost mattermost \
-  && curl -L $MM_PACKAGE | tar -xvz \
+  # && curl -L $MM_PACKAGE | tar -xvz \
+  && tar -xzf /tmp/app_package.tar.gz -C /mattermost --strip-components=1 \
+  && rm /tmp/app_package.tar.gz \
   && chown -R mattermost:mattermost /mattermost /mattermost/data /mattermost/plugins /mattermost/client/plugins
 
 # Create PostgreSQL client SSL directory structure for ssl_mode=require


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow and updates the Dockerfile to customize the CI/CD process for building and deploying Mattermost artifacts. The changes focus on replacing external dependencies with locally generated artifacts and switching to Google Cloud Artifact Registry for container image storage.

### Custom CI/CD Workflow Changes:
* [`.github/workflows/custom-ci-artifacts.yml`](diffhunk://#diff-a978d42a146dfe9171bd15c0a5695763dfd8b6fbefcfaabd855a999b8ca8a752R1-R133): Added a new workflow triggered by Git tags starting with 'v', which builds Mattermost artifacts, uploads them locally, and pushes Docker images to Google Cloud Artifact Registry instead of Docker Hub.

### Dockerfile Updates for Local Artifacts:
* [`server/build/Dockerfile`](diffhunk://#diff-9bc452b5a467a86ba3cd2df2939c749789853ae76fd928198350902c91ed11e9R13-R16): Introduced the `MM_CUSTOM_PACKAGE` argument to use locally built Mattermost artifacts instead of downloading them from external URLs.
* [`server/build/Dockerfile`](diffhunk://#diff-9bc452b5a467a86ba3cd2df2939c749789853ae76fd928198350902c91ed11e9L31-R37): Replaced the `curl` command with a local `tar` extraction process for the Mattermost package, ensuring the artifacts are sourced from the local build step.

```
* chore: Adding custom-ci-artifacts.yml

* chore: Implement workflow trigger

* chore: Implement build artifacts jobs

* chore: Implement build-and-push-image jobs

* chore: Change using local artifact

* chore: Rename MM_PACKAGE Using the default MM_PACKAGE value (a URL) in a COPY instruction will fail because COPY only accepts local paths in the build context.Consider renaming this ARG (e.g., LOCAL_PACKAGE) and requiring callers to supply a local tarball, or add logic to detect URLs and fallback to curl when needed.

* chore: Declared explicitly with an ARG instruction
```