### PR TITLE
Add the main branch as a CI trigger.

### DIFF
--- a/.github/workflows/server-ci-master.yml
+++ b/.github/workflows/server-ci-master.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
       - release-*
 
 jobs:

--- a/.github/workflows/webapp-ci-master.yml
+++ b/.github/workflows/webapp-ci-master.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
       - release-*
 
 jobs:


### PR DESCRIPTION
This pull request updates the CI workflow triggers to support both `master` and `main` as default branch names. This ensures that CI jobs run correctly regardless of which branch naming convention is used.

CI workflow configuration updates:

* [`.github/workflows/server-ci-master.yml`](diffhunk://#diff-7b89d7a082f8aaac5a4ea4e69251ae0fe3accbaa87603e66442f62bceb9b88b2R6): Added `main` to the list of branches that trigger the workflow on push events.
* [`.github/workflows/webapp-ci-master.yml`](diffhunk://#diff-5579f900111c9d632f2873268fc3975e553b6d7c0bec55af3456188d3a9a0f11R6): Added `main` to the list of branches that trigger the workflow on push events.