### PR TITLE
Fix/user search inactive filtering stmninc

### DIFF
--- a/server/cmd/mmctl/commands/user_e2e_test.go
+++ b/server/cmd/mmctl/commands/user_e2e_test.go
@@ -191,6 +191,11 @@ func (s *MmctlE2ETestSuite) TestUserDeactivationAutocompleteExclusion() {
 		}
 		s.Require().False(found, "deactivated user should not appear in autocomplete results")
 
+		// Also check OutOfChannel users are properly filtered
+		for _, u := range rusers.OutOfChannel {
+			s.Require().NotEqual(user.Id, u.Id, "deactivated user should not appear in out-of-channel autocomplete results")
+		}
+
 		// Reactivate user via mmctl
 		err = userActivateCmdF(c, &cobra.Command{}, []string{user.Email})
 		s.Require().Nil(err)
@@ -343,6 +348,11 @@ func (s *MmctlE2ETestSuite) TestUserDeactivationAutocompleteExclusionMultipleCon
 			}
 		}
 		s.Require().False(found, "deactivated user should not appear in channel autocomplete results")
+
+		// Also check that deactivated user is not in OutOfChannel list
+		for _, u := range channelUsers.OutOfChannel {
+			s.Require().NotEqual(user.Id, u.Id, "deactivated user should not appear in out-of-channel autocomplete results")
+		}
 
 		// Reactivate user via mmctl
 		err = userActivateCmdF(c, &cobra.Command{}, []string{user.Email})

--- a/server/platform/services/searchengine/bleveengine/search.go
+++ b/server/platform/services/searchengine/bleveengine/search.go
@@ -435,6 +435,13 @@ func (b *BleveEngine) SearchUsersInChannel(teamId, channelId string, restrictedT
 	channelIdQ.SetField("ChannelsIds")
 	queries = append(queries, channelIdQ)
 
+	// Filter out inactive users if AllowInactive is false
+	if !options.AllowInactive {
+		inactiveQ := bleve.NewTermQuery("0")
+		inactiveQ.SetField("DeleteAt")
+		queries = append(queries, inactiveQ)
+	}
+
 	query := bleve.NewConjunctionQuery(queries...)
 
 	uchanSearch := bleve.NewSearchRequest(query)
@@ -513,6 +520,13 @@ func (b *BleveEngine) SearchUsersInTeam(teamId string, restrictedToChannels []st
 				termQ.SetField("SuggestionsWithoutFullname")
 			}
 			boolQ.AddMust(termQ)
+		}
+
+		// Filter out inactive users if AllowInactive is false
+		if !options.AllowInactive {
+			inactiveQ := bleve.NewTermQuery("0")
+			inactiveQ.SetField("DeleteAt")
+			boolQ.AddMust(inactiveQ)
 		}
 
 		if len(restrictedToChannels) > 0 {

--- a/server/platform/services/searchengine/bleveengine/search.go
+++ b/server/platform/services/searchengine/bleveengine/search.go
@@ -481,6 +481,13 @@ func (b *BleveEngine) SearchUsersInChannel(teamId, channelId string, restrictedT
 		boolQ.AddMust(restrictedChannelsQ)
 	}
 
+	// Filter out inactive users if AllowInactive is false
+	if !options.AllowInactive {
+		inactiveQ := bleve.NewTermQuery("0")
+		inactiveQ.SetField("DeleteAt")
+		boolQ.AddMust(inactiveQ)
+	}
+
 	nuchanSearch := bleve.NewSearchRequest(boolQ)
 	nuchanSearch.Size = options.Limit
 	nuchan, err := b.UserIndex.Search(nuchanSearch)

--- a/server/platform/services/searchengine/bleveengine/search.go
+++ b/server/platform/services/searchengine/bleveengine/search.go
@@ -18,6 +18,13 @@ import (
 const DeletePostsBatchSize = 500
 const DeleteFilesBatchSize = 500
 
+// createInactiveUserFilter creates a query to filter out inactive users
+func createInactiveUserFilter() query.Query {
+	inactiveQ := bleve.NewTermQuery("0")
+	inactiveQ.SetField("DeleteAt")
+	return inactiveQ
+}
+
 func (b *BleveEngine) IndexPost(post *model.Post, teamId string) *model.AppError {
 	b.Mutex.RLock()
 	defer b.Mutex.RUnlock()
@@ -437,9 +444,7 @@ func (b *BleveEngine) SearchUsersInChannel(teamId, channelId string, restrictedT
 
 	// Filter out inactive users if AllowInactive is false
 	if !options.AllowInactive {
-		inactiveQ := bleve.NewTermQuery("0")
-		inactiveQ.SetField("DeleteAt")
-		queries = append(queries, inactiveQ)
+		queries = append(queries, createInactiveUserFilter())
 	}
 
 	query := bleve.NewConjunctionQuery(queries...)
@@ -483,9 +488,7 @@ func (b *BleveEngine) SearchUsersInChannel(teamId, channelId string, restrictedT
 
 	// Filter out inactive users if AllowInactive is false
 	if !options.AllowInactive {
-		inactiveQ := bleve.NewTermQuery("0")
-		inactiveQ.SetField("DeleteAt")
-		boolQ.AddMust(inactiveQ)
+		boolQ.AddMust(createInactiveUserFilter())
 	}
 
 	nuchanSearch := bleve.NewSearchRequest(boolQ)
@@ -531,9 +534,7 @@ func (b *BleveEngine) SearchUsersInTeam(teamId string, restrictedToChannels []st
 
 		// Filter out inactive users if AllowInactive is false
 		if !options.AllowInactive {
-			inactiveQ := bleve.NewTermQuery("0")
-			inactiveQ.SetField("DeleteAt")
-			boolQ.AddMust(inactiveQ)
+			boolQ.AddMust(createInactiveUserFilter())
 		}
 
 		if len(restrictedToChannels) > 0 {


### PR DESCRIPTION
## Summary

This PR fixes the issue where deactivated users still appeared in mention autocomplete suggestions when mentioning users from different channels. This is a follow-up to #26 which was reverted due to incomplete implementation.

## Problem

After the initial fix in #26, deactivated users were still appearing in autocomplete when mentioning users from other channels. The issue was that the `AllowInactive` filter was only applied to `InChannel` users but not to `OutOfChannel` users in the Bleve search engine.

## Solution

- Added missing `AllowInactive` filter for `OutOfChannel` users in `SearchUsersInChannel` function
- This ensures consistent behavior across all user search contexts (InChannel, OutOfChannel, Team, etc.)
- Added comprehensive test cases to verify the filtering works for all contexts

## Changes

### Files Modified
- `server/platform/services/searchengine/bleveengine/search.go`
  - Added `AllowInactive` filter to OutOfChannel user search query
- `server/cmd/mmctl/commands/user_e2e_test.go`
  - Enhanced test cases to verify OutOfChannel user filtering

## Testing

- Unit tests pass for Bleve search engine
- Added E2E test cases to verify deactivated users are excluded from all autocomplete contexts
- Manual testing confirmed the fix works for cross-channel mentions

## Related Issues

- Fixes the remaining issue from #26
- Related to mattermost/mattermost#31289

## Release Notes
