### PR TITLE
Fix fullname mention textbox when user doesn't be found

### DIFF
--- a/webapp/channels/src/components/textbox/util.test.ts
+++ b/webapp/channels/src/components/textbox/util.test.ts
@@ -506,6 +506,28 @@ describe('generateMapValueFromRawValue', () => {
         const result = generateMapValueFromRawValue(rawValue, users);
         expect(result).toBe('Hello world, no mentions here');
     });
+
+    it('should leave unknown users unchanged', () => {
+        const rawValue = 'Hello @unknown_user';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateMapValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello @unknown_user');
+    });
+
+    it('should handle mixed existing and non-existing users', () => {
+        mockDisplayUsername.mockReturnValue('John Doe');
+
+        const rawValue = 'Hello @john_doe and @unknown_user';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateMapValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello @john_doe<x-name>@John Doe</x-name> and @unknown_user');
+    });
 });
 
 describe('generateRawValueFromMapValue', () => {

--- a/webapp/channels/src/components/textbox/util.ts
+++ b/webapp/channels/src/components/textbox/util.ts
@@ -100,6 +100,9 @@ export const generateMapValueFromRawValue = (rawValue: string, usersByUsername: 
 
     for (const mapping of mentionMappings) {
         const user = usersByUsername[mapping.username];
+        if (!user) {
+            continue;
+        }
         const displayName = displayUsername(user, teammateNameDisplay, false);
         result = replaceFirstUnprocessed(result, mapping.fullMatch, `@${mapping.username}<x-name>@${displayName}</x-name>`, replacedPositions);
     }


### PR DESCRIPTION
This pull request introduces a defensive check in the `generateMapValueFromRawValue` function to ensure that user mention mappings are only processed if the corresponding user exists in the `usersByUsername` map. This helps prevent potential runtime errors when handling mentions for non-existent users. 

Error handling improvement:

* Added a guard clause in `generateMapValueFromRawValue` (`webapp/channels/src/components/textbox/util.ts`) to skip processing mention mappings if the user does not exist in `usersByUsername`.

### Before
https://github.com/user-attachments/assets/8156c82f-f520-46ed-a014-af94bf59802c

### After
https://github.com/user-attachments/assets/dad75ff0-21fe-4930-b3ee-83d0cb3e19ff