### PR TITLE
Fix fullname mention emoji picker and formatting bar and shortcut

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -43,6 +43,7 @@ import SuggestionList from 'components/suggestion/suggestion_list';
 import Textbox from 'components/textbox';
 import type {TextboxElement} from 'components/textbox';
 import type TextboxClass from 'components/textbox/textbox';
+import {convertDisplayPositionToRawPosition} from 'components/textbox/util';
 import {OnboardingTourSteps, OnboardingTourStepsForGuestUsers, TutorialTourName} from 'components/tours/constant';
 import {SendMessageTour} from 'components/tours/onboarding_tour';
 
@@ -58,7 +59,6 @@ import Constants, {
 import {canUploadFiles as canUploadFilesAccordingToConfig} from 'utils/file_utils';
 import type {ApplyMarkdownOptions} from 'utils/markdown/apply_markdown';
 import {applyMarkdown as applyMarkdownUtil} from 'utils/markdown/apply_markdown';
-import {convertDisplayPositionToRawPosition, generateDisplayValueFromRawValue} from 'components/textbox/util';
 import {isErrorInvalidSlashCommand} from 'utils/post_utils';
 import {allAtMentions} from 'utils/text_formatting';
 import * as Utils from 'utils/utils';
@@ -341,7 +341,7 @@ const AdvancedTextEditor = ({
         showPreview,
         focusTextbox,
         usersByUsername,
-        teammateNameDisplay
+        teammateNameDisplay,
     );
     const {
         labels: priorityLabels,
@@ -488,17 +488,17 @@ const AdvancedTextEditor = ({
      */
     const getCurrentValue = useCallback(() => textboxRef.current?.getInputBox().value, [textboxRef]);
     const getCurrentRawValue = useCallback(() => {
-        let rawValue = ''
+        let rawValue = '';
         if (textboxRef.current && typeof textboxRef.current.getRawValue === 'function') {
             rawValue = textboxRef.current.getRawValue();
         }
-        return rawValue.length !== 0 ? rawValue : getCurrentValue();
+        return rawValue.length === 0 ? getCurrentValue() : rawValue;
     }, [textboxRef]);
 
     const getCurrentSelection = useCallback(() => {
         const input = textboxRef.current?.getInputBox();
         if (!input) {
-            return { start: 0, end: 0 };
+            return {start: 0, end: 0};
         }
 
         const displayStart = input.selectionStart || 0;
@@ -537,7 +537,6 @@ const AdvancedTextEditor = ({
     }, [hasDraftMessage]);
 
     const handleMouseUpKeyUp = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
-
         setCaretPosition((e.target as TextboxElement).selectionStart || 0);
     }, []);
 

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -339,6 +339,8 @@ const AdvancedTextEditor = ({
         handleDraftChange,
         showPreview,
         focusTextbox,
+        usersByUsername,
+        teammateNameDisplay
     );
     const {
         labels: priorityLabels,
@@ -516,7 +518,11 @@ const AdvancedTextEditor = ({
     }, [hasDraftMessage]);
 
     const handleMouseUpKeyUp = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
-        setCaretPosition((e.target as TextboxElement).selectionStart || 0);
+        let rawValue = ''
+        if (textboxRef.current && typeof textboxRef.current.getRawValue === 'function') {
+            rawValue = textboxRef.current.getRawValue();
+        }
+        setCaretPosition(rawValue.length || (e.target as TextboxElement).selectionStart || 0);
     }, []);
 
     const prefillMessage = useCallback((message: string, shouldFocus?: boolean) => {

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -518,11 +518,8 @@ const AdvancedTextEditor = ({
     }, [hasDraftMessage]);
 
     const handleMouseUpKeyUp = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
-        let rawValue = ''
-        if (textboxRef.current && typeof textboxRef.current.getRawValue === 'function') {
-            rawValue = textboxRef.current.getRawValue();
-        }
-        setCaretPosition(rawValue.length || (e.target as TextboxElement).selectionStart || 0);
+
+        setCaretPosition((e.target as TextboxElement).selectionStart || 0);
     }, []);
 
     const prefillMessage = useCallback((message: string, shouldFocus?: boolean) => {

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -43,7 +43,7 @@ import SuggestionList from 'components/suggestion/suggestion_list';
 import Textbox from 'components/textbox';
 import type {TextboxElement} from 'components/textbox';
 import type TextboxClass from 'components/textbox/textbox';
-import {convertDisplayPositionToRawPosition} from 'components/textbox/util';
+import {convertDisplayPositionToRawPosition, convertRawPositionToDisplayPosition} from 'components/textbox/util';
 import {OnboardingTourSteps, OnboardingTourStepsForGuestUsers, TutorialTourName} from 'components/tours/constant';
 import {SendMessageTour} from 'components/tours/onboarding_tour';
 
@@ -295,7 +295,9 @@ const AdvancedTextEditor = ({
 
         setTimeout(() => {
             const textbox = textboxRef.current?.getInputBox();
-            Utils.setSelectionRange(textbox, res.selectionStart, res.selectionEnd);
+            const displaySelectionStart = convertRawPositionToDisplayPosition(res.selectionStart, res.message, usersByUsername, teammateNameDisplay);
+            const displaySelectionEnd = convertRawPositionToDisplayPosition(res.selectionEnd, res.message, usersByUsername, teammateNameDisplay);
+            Utils.setSelectionRange(textbox, displaySelectionStart, displaySelectionEnd);
         });
     }, [showPreview, handleDraftChange, draft]);
 

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -426,6 +426,14 @@ const AdvancedTextEditor = ({
         handleSubmitWithErrorHandling();
     }, [dispatch, draft, handleSubmitWithErrorHandling, isInEditMode, isRHS]);
 
+    const getCurrentRawValue = useCallback(() => {
+        let rawValue = '';
+        if (textboxRef.current && typeof textboxRef.current.getRawValue === 'function') {
+            rawValue = textboxRef.current.getRawValue();
+        }
+        return rawValue.length === 0 ? getCurrentValue() : rawValue;
+    }, [textboxRef]);
+
     const [handleKeyDown, postMsgKeyPress] = useKeyHandler(
         draft,
         channelId,
@@ -445,6 +453,9 @@ const AdvancedTextEditor = ({
         toggleEmojiPicker,
         isInEditMode,
         handleCancel,
+        getCurrentRawValue,
+        usersByUsername,
+        teammateNameDisplay,
     );
 
     const handleSubmitWithEvent = useCallback((e: React.FormEvent) => {
@@ -489,13 +500,6 @@ const AdvancedTextEditor = ({
      * although still working as expected
      */
     const getCurrentValue = useCallback(() => textboxRef.current?.getInputBox().value, [textboxRef]);
-    const getCurrentRawValue = useCallback(() => {
-        let rawValue = '';
-        if (textboxRef.current && typeof textboxRef.current.getRawValue === 'function') {
-            rawValue = textboxRef.current.getRawValue();
-        }
-        return rawValue.length === 0 ? getCurrentValue() : rawValue;
-    }, [textboxRef]);
 
     const getCurrentSelection = useCallback(() => {
         const input = textboxRef.current?.getInputBox();

--- a/webapp/channels/src/components/advanced_text_editor/use_editor_emoji_picker.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_editor_emoji_picker.tsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import React, {useCallback, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
+import type {UserProfile} from '@mattermost/types/users';
 
 import {EmoticonHappyOutlineIcon} from '@mattermost/compass-icons/components';
 import type {Emoji} from '@mattermost/types/emojis';
@@ -26,7 +27,7 @@ import type {PostDraft} from 'types/store/draft';
 
 import {IconContainer} from './formatting_bar/formatting_icon';
 
-import {generateDisplayValueFromRawValue, generateMapValueFromRawValue, convertDisplayPositionToRawPosition} from 'components/textbox/util';
+import {generateDisplayValueFromRawValue, convertDisplayPositionToRawPosition} from 'components/textbox/util';
 
 const useEditorEmojiPicker = (
     textboxId: string,
@@ -37,7 +38,7 @@ const useEditorEmojiPicker = (
     handleDraftChange: (draft: PostDraft) => void,
     shouldShowPreview: boolean,
     focusTextbox: () => void,
-    usersByUsername?: Record<string, any>,
+    usersByUsername?: Record<string, UserProfile>,
     teammateNameDisplay?: string
 ) => {
     const intl = useIntl();

--- a/webapp/channels/src/components/advanced_text_editor/use_editor_emoji_picker.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_editor_emoji_picker.tsx
@@ -26,7 +26,7 @@ import type {PostDraft} from 'types/store/draft';
 
 import {IconContainer} from './formatting_bar/formatting_icon';
 
-import {generateDisplayValueFromRawValue} from 'components/textbox/util';
+import {generateDisplayValueFromRawValue, generateMapValueFromRawValue, convertDisplayPositionToRawPosition} from 'components/textbox/util';
 
 const useEditorEmojiPicker = (
     textboxId: string,
@@ -67,8 +67,10 @@ const useEditorEmojiPicker = (
             setCaretPosition(newMessage.length);
         } else {
             const {message} = draft;
-            const {firstPiece, lastPiece} = splitMessageBasedOnCaretPosition(caretPosition, message);
             const displayValue = generateDisplayValueFromRawValue(draft.message, usersByUsername, teammateNameDisplay);
+            const rawCaretPosition = convertDisplayPositionToRawPosition(caretPosition, message, usersByUsername, teammateNameDisplay);
+
+            const {firstPiece, lastPiece} = splitMessageBasedOnCaretPosition(rawCaretPosition, message);
             const {firstPiece: displayFirstPiece, lastPiece: _} = splitMessageBasedOnCaretPosition(caretPosition, displayValue);
 
             // check whether the first piece of the message is empty when cursor is placed at beginning of message and avoid adding an empty string at the beginning of the message

--- a/webapp/channels/src/components/advanced_text_editor/use_editor_emoji_picker.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_editor_emoji_picker.tsx
@@ -6,10 +6,10 @@ import classNames from 'classnames';
 import React, {useCallback, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
-import type {UserProfile} from '@mattermost/types/users';
 
 import {EmoticonHappyOutlineIcon} from '@mattermost/compass-icons/components';
 import type {Emoji} from '@mattermost/types/emojis';
+import type {UserProfile} from '@mattermost/types/users';
 
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getEmojiName} from 'mattermost-redux/utils/emoji_utils';
@@ -17,6 +17,7 @@ import {getEmojiName} from 'mattermost-redux/utils/emoji_utils';
 import useDidUpdate from 'components/common/hooks/useDidUpdate';
 import useEmojiPicker, {useEmojiPickerOffset} from 'components/emoji_picker/use_emoji_picker';
 import KeyboardShortcutSequence, {KEYBOARD_SHORTCUTS} from 'components/keyboard_shortcuts/keyboard_shortcuts_sequence';
+import {generateDisplayValueFromRawValue, convertDisplayPositionToRawPosition} from 'components/textbox/util';
 import WithTooltip from 'components/with_tooltip';
 
 import {horizontallyWithin} from 'utils/floating';
@@ -26,8 +27,6 @@ import type {GlobalState} from 'types/store';
 import type {PostDraft} from 'types/store/draft';
 
 import {IconContainer} from './formatting_bar/formatting_icon';
-
-import {generateDisplayValueFromRawValue, convertDisplayPositionToRawPosition} from 'components/textbox/util';
 
 const useEditorEmojiPicker = (
     textboxId: string,
@@ -39,7 +38,7 @@ const useEditorEmojiPicker = (
     shouldShowPreview: boolean,
     focusTextbox: () => void,
     usersByUsername?: Record<string, UserProfile>,
-    teammateNameDisplay?: string
+    teammateNameDisplay?: string,
 ) => {
     const intl = useIntl();
 
@@ -72,7 +71,7 @@ const useEditorEmojiPicker = (
             const rawCaretPosition = convertDisplayPositionToRawPosition(caretPosition, message, usersByUsername, teammateNameDisplay);
 
             const {firstPiece, lastPiece} = splitMessageBasedOnCaretPosition(rawCaretPosition, message);
-            const {firstPiece: displayFirstPiece, lastPiece: _} = splitMessageBasedOnCaretPosition(caretPosition, displayValue);
+            const {firstPiece: displayFirstPiece} = splitMessageBasedOnCaretPosition(caretPosition, displayValue);
 
             // check whether the first piece of the message is empty when cursor is placed at beginning of message and avoid adding an empty string at the beginning of the message
             newMessage =

--- a/webapp/channels/src/components/advanced_text_editor/use_editor_emoji_picker.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_editor_emoji_picker.tsx
@@ -26,6 +26,8 @@ import type {PostDraft} from 'types/store/draft';
 
 import {IconContainer} from './formatting_bar/formatting_icon';
 
+import {generateDisplayValueFromRawValue} from 'components/textbox/util';
+
 const useEditorEmojiPicker = (
     textboxId: string,
     isDisabled: boolean,
@@ -35,6 +37,8 @@ const useEditorEmojiPicker = (
     handleDraftChange: (draft: PostDraft) => void,
     shouldShowPreview: boolean,
     focusTextbox: () => void,
+    usersByUsername?: Record<string, any>,
+    teammateNameDisplay?: string
 ) => {
     const intl = useIntl();
 
@@ -64,13 +68,15 @@ const useEditorEmojiPicker = (
         } else {
             const {message} = draft;
             const {firstPiece, lastPiece} = splitMessageBasedOnCaretPosition(caretPosition, message);
+            const displayValue = generateDisplayValueFromRawValue(draft.message, usersByUsername, teammateNameDisplay);
+            const {firstPiece: displayFirstPiece, lastPiece: _} = splitMessageBasedOnCaretPosition(caretPosition, displayValue);
 
             // check whether the first piece of the message is empty when cursor is placed at beginning of message and avoid adding an empty string at the beginning of the message
             newMessage =
                 firstPiece === '' ? `:${emojiAlias}: ${lastPiece}` : `${firstPiece} :${emojiAlias}: ${lastPiece}`;
 
             const newCaretPosition =
-                firstPiece === '' ? `:${emojiAlias}: `.length : `${firstPiece} :${emojiAlias}: `.length;
+                displayFirstPiece === '' ? `:${emojiAlias}: `.length : `${displayFirstPiece} :${emojiAlias}: `.length;
             setCaretPosition(newCaretPosition);
         }
 

--- a/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
@@ -16,6 +16,7 @@ import {getIsRhsExpanded} from 'selectors/rhs';
 
 import type {TextboxElement} from 'components/textbox';
 import type TextboxClass from 'components/textbox/textbox';
+import {convertDisplayPositionToRawPosition} from 'components/textbox/util';
 
 import Constants, {A11yClassNames, Locations, Preferences} from 'utils/constants';
 import * as Keyboard from 'utils/keyboard';
@@ -49,6 +50,9 @@ const useKeyHandler = (
     toggleEmojiPicker: () => void,
     isInEditMode?: boolean,
     onCancel?: () => void,
+    getCurrentRawValue?: () => string,
+    usersByUsername?: Record<string, any>,
+    teammateNameDisplay?: string,
 ): [
         (e: React.KeyboardEvent<TextboxElement>) => void,
         (e: React.KeyboardEvent<TextboxElement>) => void,
@@ -205,10 +209,23 @@ const useKeyHandler = (
         }
 
         const {
-            selectionStart,
-            selectionEnd,
-            value,
+            selectionStart: displaySelectionStart,
+            selectionEnd: displaySelectionEnd,
         } = e.target as TextboxElement;
+
+        const value = getCurrentRawValue?.() || '';
+        const selectionStart = convertDisplayPositionToRawPosition(
+            displaySelectionStart || 0,
+            value,
+            usersByUsername,
+            teammateNameDisplay,
+        );
+        const selectionEnd = convertDisplayPositionToRawPosition(
+            displaySelectionEnd || 0,
+            value,
+            usersByUsername,
+            teammateNameDisplay,
+        );
 
         if (ctrlKeyCombo && !caretIsWithinCodeBlock) {
             if (allowHistoryNavigation && Keyboard.isKeyPressed(e, KeyCodes.UP)) {
@@ -366,19 +383,31 @@ const useKeyHandler = (
         toggleShowPreview,
         isInEditMode,
         location,
+        getCurrentRawValue,
+        usersByUsername,
+        teammateNameDisplay,
     ]);
 
     // Register paste events
     useEffect(() => {
         function onPaste(event: ClipboardEvent) {
-            pasteHandler(event, location, draft.message, isNonFormattedPaste.current, caretPosition, isInEditMode);
+            pasteHandler(
+                event, 
+                location, 
+                draft.message, 
+                isNonFormattedPaste.current, 
+                caretPosition, 
+                isInEditMode,
+                usersByUsername,
+                teammateNameDisplay,
+            );
         }
 
         document.addEventListener('paste', onPaste);
         return () => {
             document.removeEventListener('paste', onPaste);
         };
-    }, [location, draft.message, caretPosition, isInEditMode]);
+    }, [location, draft.message, caretPosition, isInEditMode, usersByUsername, teammateNameDisplay]);
 
     const reactToLastMessage = useCallback((e: KeyboardEvent) => {
         e.preventDefault();

--- a/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
@@ -6,6 +6,7 @@ import {useCallback, useEffect, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import type {SchedulingInfo} from '@mattermost/types/schedule_post';
+import type {UserProfile} from '@mattermost/types/users';
 
 import {getBool} from 'mattermost-redux/selectors/entities/preferences';
 
@@ -51,7 +52,7 @@ const useKeyHandler = (
     isInEditMode?: boolean,
     onCancel?: () => void,
     getCurrentRawValue?: () => string,
-    usersByUsername?: Record<string, any>,
+    usersByUsername?: Record<string, UserProfile>,
     teammateNameDisplay?: string,
 ): [
         (e: React.KeyboardEvent<TextboxElement>) => void,
@@ -392,11 +393,11 @@ const useKeyHandler = (
     useEffect(() => {
         function onPaste(event: ClipboardEvent) {
             pasteHandler(
-                event, 
-                location, 
-                draft.message, 
-                isNonFormattedPaste.current, 
-                caretPosition, 
+                event,
+                location,
+                draft.message,
+                isNonFormattedPaste.current,
+                caretPosition,
                 isInEditMode,
                 usersByUsername,
                 teammateNameDisplay,

--- a/webapp/channels/src/components/textbox/util.test.ts
+++ b/webapp/channels/src/components/textbox/util.test.ts
@@ -1148,7 +1148,7 @@ describe('convertDisplayPositionToRawPosition', () => {
     it('should return displayPosition when usersByUsername is undefined', () => {
         const displayPosition = 10;
         const rawValue = 'Hello @john_doe';
-        
+
         const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, undefined);
         expect(result).toBe(displayPosition);
     });
@@ -1431,6 +1431,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users);
+
         // Raw: "Hello @john_doe, how are you?" (position 20 = "are y")
         // Display: "Hello @John Doe, how are you?" (position 20 = "are y")
         // The difference is "John Doe" (8 chars) vs "john_doe" (8 chars) = no difference
@@ -1450,6 +1451,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users);
+
         // Raw: "Hello @john_doe and @jane_smith" (31 chars)
         // Display: "Hello @John Doe and @Jane Smith" (31 chars)
         // Both have same length, so position should be same
@@ -1469,6 +1471,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users);
+
         // Raw: "Hello @john_doe and" (position 18 = "d")
         // Display: "Hello @John Doe and" (position 18 = "d")
         // Both mentions have same length, so position should be same
@@ -1485,6 +1488,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users);
+
         // Raw: "Hello @john_doe" (15 chars)
         // Display: "Hello @John Michael Doe" (23 chars)
         expect(result).toBe(23);
@@ -1500,6 +1504,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users);
+
         // Raw: "Hello @john_doe" (15 chars)
         // Display: "Hello @John" (11 chars)
         expect(result).toBe(11);
@@ -1515,6 +1520,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users);
+
         // Raw: "Hello @test.user-name_123" (22 chars)
         // Display: "Hello @Test User" (16 chars)
         expect(result).toBe(16);
@@ -1530,6 +1536,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users, Preferences.DISPLAY_PREFER_FULL_NAME);
+
         // Raw: "Hello @john_doe" (15 chars)
         // Display: "Hello @John (john_doe)" (22 chars)
         expect(result).toBe(22);
@@ -1596,6 +1603,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users);
+
         // Raw: "こんにちは @tanaka" (13 chars)
         // Display: "こんにちは @田中太郎" (11 chars)
         expect(result).toBe(11);
@@ -1611,6 +1619,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users);
+
         // Raw: "Hi @john_doe, @john_doe there" (29 chars)
         // Display: "Hi @John Doe, @John Doe there" (29 chars)
         expect(result).toBe(29); // End of display value
@@ -1629,6 +1638,7 @@ describe('convertRawPositionToDisplayPosition', () => {
         };
 
         const result = convertRawPositionToDisplayPosition(rawPosition, rawValue, users);
+
         // Raw: "@john_doe@jane_smith" (20 chars)
         // Display: "@John Doe@Jane Smith" (20 chars)
         expect(result).toBe(20); // End of display value

--- a/webapp/channels/src/components/textbox/util.test.ts
+++ b/webapp/channels/src/components/textbox/util.test.ts
@@ -5,7 +5,7 @@ import type {UserProfile} from '@mattermost/types/users';
 
 import {Preferences} from 'mattermost-redux/constants';
 
-import {generateMapValueFromInputValue, generateDisplayValueFromMapValue, generateRawValueFromInputValue, generateMapValueFromRawValue, generateRawValueFromMapValue, calculateMentionPositions} from './util';
+import {generateMapValueFromInputValue, generateDisplayValueFromMapValue, generateRawValueFromInputValue, generateMapValueFromRawValue, generateRawValueFromMapValue, calculateMentionPositions, generateDisplayValueFromRawValue, convertDisplayPositionToRawPosition} from './util';
 
 const mockDisplayUsername = require('mattermost-redux/utils/user_utils').displayUsername;
 
@@ -926,5 +926,437 @@ describe('calculateMentionPositions', () => {
                 username: 'user2',
             },
         ]);
+    });
+});
+describe('generateDisplayValueFromRawValue', () => {
+    beforeEach(() => {
+        mockDisplayUsername.mockClear();
+    });
+
+    it('should convert raw username to display format', () => {
+        mockDisplayUsername.mockReturnValue('John Doe');
+
+        const rawValue = 'Hello @john_doe';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello @John Doe');
+        expect(mockDisplayUsername).toHaveBeenCalledWith(users.john_doe, Preferences.DISPLAY_PREFER_USERNAME, false);
+    });
+
+    it('should convert multiple mentions from raw to display format', () => {
+        mockDisplayUsername.
+            mockReturnValueOnce('John Doe').
+            mockReturnValueOnce('Jane Smith');
+
+        const rawValue = 'Hello @john_doe and @jane_smith';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+            jane_smith: {id: '2', username: 'jane_smith'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello @John Doe and @Jane Smith');
+    });
+
+    it('should handle usernames with special characters', () => {
+        mockDisplayUsername.mockReturnValue('Test User');
+
+        const rawValue = 'Hello @test.user-name_123';
+        const users = {
+            'test.user-name_123': {id: '1', username: 'test.user-name_123'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello @Test User');
+    });
+
+    it('should handle same username mentioned multiple times', () => {
+        mockDisplayUsername.mockReturnValue('John Doe');
+
+        const rawValue = 'Hi @john_doe, @john_doe are you there?';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hi @John Doe, @John Doe are you there?');
+    });
+
+    it('should handle display names with special characters', () => {
+        mockDisplayUsername.mockReturnValue('John O\'Connor-Smith');
+
+        const rawValue = 'Hello @john.oconnor';
+        const users = {
+            'john.oconnor': {id: '1', username: 'john.oconnor'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello @John O\'Connor-Smith');
+    });
+
+    it('should handle Japanese display names', () => {
+        mockDisplayUsername.mockReturnValue('田中 太郎');
+
+        const rawValue = 'こんにちは @tanaka.taro';
+        const users = {
+            'tanaka.taro': {id: '1', username: 'tanaka.taro'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('こんにちは @田中 太郎');
+    });
+
+    it('should respect custom teammateNameDisplay preference', () => {
+        mockDisplayUsername.mockReturnValue('John (john_doe)');
+
+        const rawValue = 'Hello @john_doe';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users, Preferences.DISPLAY_PREFER_FULL_NAME);
+        expect(result).toBe('Hello @John (john_doe)');
+        expect(mockDisplayUsername).toHaveBeenCalledWith(users.john_doe, Preferences.DISPLAY_PREFER_FULL_NAME, false);
+    });
+
+    it('should handle mentions at beginning and end of text', () => {
+        mockDisplayUsername.
+            mockReturnValueOnce('John Doe').
+            mockReturnValueOnce('Jane Smith');
+
+        const rawValue = '@john_doe hello @jane_smith';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+            jane_smith: {id: '2', username: 'jane_smith'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('@John Doe hello @Jane Smith');
+    });
+
+    it('should handle consecutive mentions without spaces', () => {
+        mockDisplayUsername.
+            mockReturnValueOnce('John Doe').
+            mockReturnValueOnce('Jane Smith');
+
+        const rawValue = '@john_doe@jane_smith';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+            jane_smith: {id: '2', username: 'jane_smith'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('@John Doe@Jane Smith');
+    });
+
+    it('should handle empty string input', () => {
+        const rawValue = '';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('');
+    });
+
+    it('should handle text without mentions', () => {
+        const rawValue = 'Hello world, no mentions here';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello world, no mentions here');
+    });
+
+    it('should leave unknown users unchanged', () => {
+        const rawValue = 'Hello @unknown_user';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello @unknown_user');
+    });
+
+    it('should handle mixed existing and non-existing users', () => {
+        mockDisplayUsername.mockReturnValue('John Doe');
+
+        const rawValue = 'Hello @john_doe and @unknown_user';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello @John Doe and @unknown_user');
+    });
+
+    it('should handle empty usersByUsername object', () => {
+        const rawValue = 'Hello @john_doe';
+        const users = {};
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Hello @john_doe');
+    });
+
+    it('should handle display names with spaces and punctuation', () => {
+        mockDisplayUsername.mockReturnValue('Dr. John Smith Jr.');
+
+        const rawValue = 'Meeting with @john.smith tomorrow';
+        const users = {
+            'john.smith': {id: '1', username: 'john.smith'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Meeting with @Dr. John Smith Jr. tomorrow');
+    });
+
+    it('should handle @ symbol without valid username', () => {
+        const rawValue = 'Email: test@example.com and @';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Email: test@example.com and @');
+    });
+
+    it('should handle mentions with identical display names correctly', () => {
+        mockDisplayUsername.
+            mockReturnValueOnce('John Smith').
+            mockReturnValueOnce('John Smith');
+
+        const rawValue = 'Both @john.smith1 and @john.smith2 are here';
+        const users = {
+            'john.smith1': {id: '1', username: 'john.smith1'} as UserProfile,
+            'john.smith2': {id: '2', username: 'john.smith2'} as UserProfile,
+        };
+
+        const result = generateDisplayValueFromRawValue(rawValue, users);
+        expect(result).toBe('Both @John Smith and @John Smith are here');
+    });
+});
+
+describe('convertDisplayPositionToRawPosition', () => {
+    beforeEach(() => {
+        mockDisplayUsername.mockClear();
+    });
+
+    it('should return displayPosition when usersByUsername is undefined', () => {
+        const displayPosition = 10;
+        const rawValue = 'Hello @john_doe';
+        
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, undefined);
+        expect(result).toBe(displayPosition);
+    });
+
+    it('should return displayPosition when displayPosition is 0 or negative', () => {
+        const rawValue = 'Hello @john_doe';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        expect(convertDisplayPositionToRawPosition(0, rawValue, users)).toBe(0);
+        expect(convertDisplayPositionToRawPosition(-5, rawValue, users)).toBe(-5);
+    });
+
+    it('should convert position correctly when no mentions exist', () => {
+        const displayPosition = 10;
+        const rawValue = 'Hello world!';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(displayPosition);
+    });
+
+    it('should convert position before a mention correctly', () => {
+        mockDisplayUsername.mockReturnValue('John Doe');
+
+        const displayPosition = 6; // Position before '@' in "Hello @John Doe"
+        const rawValue = 'Hello @john_doe';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(6); // Same position in raw value
+    });
+
+    it('should convert position within a mention to end of username', () => {
+        mockDisplayUsername.mockReturnValue('John Doe');
+
+        const displayPosition = 10; // Position within "@John Doe" in "Hello @John Doe"
+        const rawValue = 'Hello @john_doe';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(15); // End of "@john_doe"
+    });
+
+    it('should convert position after a mention correctly', () => {
+        mockDisplayUsername.mockReturnValue('John Doe');
+
+        const displayPosition = 17; // Position after "Hello @John Doe "
+        const rawValue = 'Hello @john_doe how are you?';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(17); // Position after "Hello @john_doe "
+    });
+
+    it('should handle multiple mentions correctly', () => {
+        mockDisplayUsername.
+            mockReturnValueOnce('John Doe').
+            mockReturnValueOnce('Jane Smith');
+
+        const displayPosition = 25; // Position after "Hello @John Doe and @Jane Smith"
+        const rawValue = 'Hello @john_doe and @jane_smith';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+            jane_smith: {id: '2', username: 'jane_smith'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(31); // End of raw value
+    });
+
+    it('should handle position between multiple mentions', () => {
+        mockDisplayUsername.
+            mockReturnValueOnce('John Doe').
+            mockReturnValueOnce('Jane Smith');
+
+        const displayPosition = 15; // Position in " and " between mentions
+        const rawValue = 'Hello @john_doe and @jane_smith';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+            jane_smith: {id: '2', username: 'jane_smith'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(15); // Position in " and " in raw value
+    });
+
+    it('should handle display names longer than usernames', () => {
+        mockDisplayUsername.mockReturnValue('Dr. John Smith Jr.');
+
+        const displayPosition = 25; // Position after "Hello @Dr. John Smith Jr."
+        const rawValue = 'Hello @john_smith';
+        const users = {
+            john_smith: {id: '1', username: 'john_smith'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(17); // End of raw value
+    });
+
+    it('should handle display names shorter than usernames', () => {
+        mockDisplayUsername.mockReturnValue('John');
+
+        const displayPosition = 12; // Position after "Hello @John "
+        const rawValue = 'Hello @john_doe_long how are you?';
+        const users = {
+            john_doe_long: {id: '1', username: 'john_doe_long'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(21); // Position after "Hello @john_doe_long "
+    });
+
+    it('should handle mentions with special characters', () => {
+        mockDisplayUsername.mockReturnValue('John-Doe');
+
+        const displayPosition = 13; // Position after "Hello @John-Doe"
+        const rawValue = 'Hello @john.doe';
+        const users = {
+            'john.doe': {id: '1', username: 'john.doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(15); // End of "@john.doe"
+    });
+
+    it('should respect custom teammateNameDisplay preference', () => {
+        mockDisplayUsername.mockReturnValue('j.doe');
+
+        const displayPosition = 12; // Position after "Hello @j.doe"
+        const rawValue = 'Hello @john_doe';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users, Preferences.DISPLAY_PREFER_NICKNAME);
+        expect(result).toBe(15); // End of "@john_doe"
+    });
+
+    it('should handle position at the exact start of a mention', () => {
+        mockDisplayUsername.mockReturnValue('John Doe');
+
+        const displayPosition = 6; // Position at '@' in "Hello @John Doe"
+        const rawValue = 'Hello @john_doe';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(6); // Same position at '@' in raw value
+    });
+
+    it('should handle position at the exact end of a mention', () => {
+        mockDisplayUsername.mockReturnValue('John Doe');
+
+        const displayPosition = 15; // Position right after "Hello @John Doe"
+        const rawValue = 'Hello @john_doe';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(15); // End of raw value
+    });
+
+    it('should handle empty rawValue', () => {
+        const displayPosition = 0;
+        const rawValue = '';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(0);
+    });
+
+    it('should clamp position to rawValue length when displayPosition exceeds boundaries', () => {
+        mockDisplayUsername.mockReturnValue('John');
+
+        const displayPosition = 100; // Position way beyond the text
+        const rawValue = 'Hello @john_doe';
+        const users = {
+            john_doe: {id: '1', username: 'john_doe'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(15); // Clamped to rawValue length
+    });
+
+    it('should handle Japanese text with mentions', () => {
+        mockDisplayUsername.mockReturnValue('田中太郎');
+
+        const displayPosition = 8; // Position after "こんにちは @田中太郎"
+        const rawValue = 'こんにちは @tanaka';
+        const users = {
+            tanaka: {id: '1', username: 'tanaka'} as UserProfile,
+        };
+
+        const result = convertDisplayPositionToRawPosition(displayPosition, rawValue, users);
+        expect(result).toBe(13); // End of raw value
     });
 });

--- a/webapp/channels/src/components/textbox/util.ts
+++ b/webapp/channels/src/components/textbox/util.ts
@@ -165,6 +165,7 @@ export const generateRawValueFromMapValue = (mapValue: string, inputValue: strin
  */
 export const generateDisplayValueFromRawValue = (rawValue: string, usersByUsername: Record<string, UserProfile> = {}, teammateNameDisplay = Preferences.DISPLAY_PREFER_USERNAME): string => {
     const mentionMappings = extractMentionRawMappings(rawValue);
+    const processedPositions = new Set<number>();
 
     let result = rawValue;
     for (const mapping of mentionMappings) {
@@ -173,7 +174,7 @@ export const generateDisplayValueFromRawValue = (rawValue: string, usersByUserna
             continue;
         }
         const displayName = displayUsername(user, teammateNameDisplay, false);
-        result = replaceFirstUnprocessed(result, mapping.fullMatch, `@${displayName}`, new Set());
+        result = replaceFirstUnprocessed(result, mapping.fullMatch, `@${displayName}`, processedPositions);
     }
     return result;
 };

--- a/webapp/channels/src/components/textbox/util.ts
+++ b/webapp/channels/src/components/textbox/util.ts
@@ -233,9 +233,10 @@ export const convertDisplayPositionToRawPosition = (
             displayEnd,
         });
 
-        const tagLength = fullMatch.length - displayMentionLength;
-        rawOffset += tagLength;
-        displayOffset += tagLength;
+        const rawOffsetIncrement = fullMatch.length - rawMentionLength;
+        const displayOffsetIncrement = fullMatch.length - displayMentionLength;
+        rawOffset += rawOffsetIncrement;
+        displayOffset += displayOffsetIncrement;
     }
 
     let rawPosition = displayPosition;

--- a/webapp/channels/src/components/textbox/util.ts
+++ b/webapp/channels/src/components/textbox/util.ts
@@ -191,14 +191,14 @@ export const convertDisplayPositionToRawPosition = (
     displayPosition: number,
     rawValue: string,
     usersByUsername?: Record<string, UserProfile>,
-    teammateNameDisplay = Preferences.DISPLAY_PREFER_USERNAME
+    teammateNameDisplay = Preferences.DISPLAY_PREFER_USERNAME,
 ): number => {
     if (!usersByUsername || displayPosition <= 0) {
         return displayPosition;
     }
 
     const mapValue = generateMapValueFromRawValue(rawValue, usersByUsername, teammateNameDisplay);
-    
+
     const mentions: Array<{
         username: string;
         displayName: string;

--- a/webapp/channels/src/components/textbox/util.ts
+++ b/webapp/channels/src/components/textbox/util.ts
@@ -156,6 +156,21 @@ export const generateRawValueFromMapValue = (mapValue: string, inputValue: strin
     return result;
 };
 
+export const generateDisplayValueFromRawValue = (rawValue: string, usersByUsername: Record<string, UserProfile> = {}, teammateNameDisplay = Preferences.DISPLAY_PREFER_USERNAME): string => {
+    const mentionMappings = extractMentionRawMappings(rawValue);
+
+    let result = rawValue;
+    for (const mapping of mentionMappings) {
+        const user = usersByUsername[mapping.username];
+        if (!user) {
+            continue;
+        }
+        const displayName = displayUsername(user, teammateNameDisplay, false);
+        result = replaceFirstUnprocessed(result, mapping.fullMatch, `@${displayName}`, new Set());
+    }
+    return result;
+};
+
 /**
  * Updates the component state when a mention suggestion is selected.
  * @param item - The selected suggestion item.

--- a/webapp/channels/src/components/textbox/util.ts
+++ b/webapp/channels/src/components/textbox/util.ts
@@ -257,6 +257,90 @@ export const convertDisplayPositionToRawPosition = (
 };
 
 /**
+ * Converts a raw position to a display position.
+ * @param rawPosition - The position in the raw value.
+ * @param rawValue - The raw value.
+ * @param usersByUsername - A mapping of usernames to user profiles.
+ * @param teammateNameDisplay - The display setting for teammate names.
+ * @returns The corresponding position in the display value.
+ */
+export const convertRawPositionToDisplayPosition = (
+    rawPosition: number,
+    rawValue: string,
+    usersByUsername?: Record<string, UserProfile>,
+    teammateNameDisplay = Preferences.DISPLAY_PREFER_USERNAME,
+): number => {
+    if (!usersByUsername || rawPosition <= 0) {
+        return rawPosition;
+    }
+
+    const mapValue = generateMapValueFromRawValue(rawValue, usersByUsername, teammateNameDisplay);
+
+    const mentions: Array<{
+        username: string;
+        displayName: string;
+        rawStart: number;
+        rawEnd: number;
+        displayStart: number;
+        displayEnd: number;
+    }> = [];
+
+    let match;
+    let rawOffset = 0;
+    let displayOffset = 0;
+
+    while ((match = MENTION_REGEX.exec(mapValue)) !== null) {
+        const [fullMatch, username, displayName] = match;
+        const rawMentionLength = `@${username}`.length;
+        const displayMentionLength = `@${displayName}`.length;
+        const mapMentionStart = match.index;
+
+        const rawStart = mapMentionStart - rawOffset;
+        const rawEnd = rawStart + rawMentionLength;
+
+        const displayStart = mapMentionStart - displayOffset;
+        const displayEnd = displayStart + displayMentionLength;
+
+        mentions.push({
+            username,
+            displayName,
+            rawStart,
+            rawEnd,
+            displayStart,
+            displayEnd,
+        });
+
+        const rawOffsetIncrement = fullMatch.length - rawMentionLength;
+        const displayOffsetIncrement = fullMatch.length - displayMentionLength;
+        rawOffset += rawOffsetIncrement;
+        displayOffset += displayOffsetIncrement;
+    }
+
+    let displayPosition = rawPosition;
+    let accumulatedLengthDiff = 0;
+
+    for (const mention of mentions) {
+        if (rawPosition <= mention.rawStart) {
+            displayPosition = rawPosition + accumulatedLengthDiff;
+            break;
+        } else if (rawPosition <= mention.rawEnd) {
+            displayPosition = mention.displayEnd;
+            break;
+        } else {
+            const lengthDiff = mention.displayEnd - mention.displayStart - (mention.rawEnd - mention.rawStart);
+            accumulatedLengthDiff += lengthDiff;
+        }
+    }
+
+    if (mentions.length > 0 && rawPosition > mentions[mentions.length - 1].rawEnd) {
+        displayPosition = rawPosition + accumulatedLengthDiff;
+    }
+
+    const displayValue = generateDisplayValueFromMapValue(mapValue);
+    return Math.max(0, Math.min(displayPosition, displayValue.length));
+};
+
+/**
  * Updates the component state when a mention suggestion is selected.
  * @param item - The selected suggestion item.
  * @param inputValue - The current input value.

--- a/webapp/channels/src/utils/markdown/apply_markdown.ts
+++ b/webapp/channels/src/utils/markdown/apply_markdown.ts
@@ -53,6 +53,7 @@ export function applyMarkdown(options: ApplyMarkdownOptions): ApplyMarkdownRetur
      *
      * In a strange case where nothing works we throw an error.
      */
+    console.log('markdownModel', 'selectionEnd', selectionEnd, 'selectionStart', selectionStart, 'message', message)
     switch (markdownMode) {
     case 'bold':
         return applyBoldMarkdown({selectionEnd, selectionStart, message});

--- a/webapp/channels/src/utils/markdown/apply_markdown.ts
+++ b/webapp/channels/src/utils/markdown/apply_markdown.ts
@@ -53,7 +53,6 @@ export function applyMarkdown(options: ApplyMarkdownOptions): ApplyMarkdownRetur
      *
      * In a strange case where nothing works we throw an error.
      */
-    console.log('markdownModel', 'selectionEnd', selectionEnd, 'selectionStart', selectionStart, 'message', message)
     switch (markdownMode) {
     case 'bold':
         return applyBoldMarkdown({selectionEnd, selectionStart, message});

--- a/webapp/channels/src/utils/paste.tsx
+++ b/webapp/channels/src/utils/paste.tsx
@@ -178,11 +178,11 @@ export function isKnownTargetForPaste(event: ClipboardEvent, location: string, i
 }
 
 export function pasteHandler(
-    event: ClipboardEvent, 
-    location: string, 
-    message: string, 
-    isNonFormattedPaste: boolean, 
-    caretPosition?: number, 
+    event: ClipboardEvent,
+    location: string,
+    message: string,
+    isNonFormattedPaste: boolean,
+    caretPosition?: number,
     isInEditMode?: boolean,
     usersByUsername?: Record<string, any>,
     teammateNameDisplay?: string,
@@ -215,14 +215,14 @@ export function pasteHandler(
     );
 
     // Convert caretPosition from display to raw position if needed
-    const rawCaretPosition = caretPosition !== undefined 
-        ? convertDisplayPositionToRawPosition(
+    const rawCaretPosition = caretPosition === undefined ?
+        undefined :
+        convertDisplayPositionToRawPosition(
             caretPosition,
             message,
             usersByUsername,
             teammateNameDisplay,
-        )
-        : undefined;
+        );
 
     const hasSelection = !isNil(selectionStart) && !isNil(selectionEnd) && selectionStart < selectionEnd;
     const hasTextUrl = isTextUrl(clipboardData);

--- a/webapp/channels/src/utils/paste.tsx
+++ b/webapp/channels/src/utils/paste.tsx
@@ -4,6 +4,7 @@
 import isNil from 'lodash/isNil';
 
 import type {TextboxElement} from 'components/textbox';
+import {convertDisplayPositionToRawPosition} from 'components/textbox/util';
 
 import {Locations} from 'utils/constants';
 import {execCommandInsertText} from 'utils/exec_commands';
@@ -176,7 +177,16 @@ export function isKnownTargetForPaste(event: ClipboardEvent, location: string, i
     return isKnownTarget;
 }
 
-export function pasteHandler(event: ClipboardEvent, location: string, message: string, isNonFormattedPaste: boolean, caretPosition?: number, isInEditMode?: boolean) {
+export function pasteHandler(
+    event: ClipboardEvent, 
+    location: string, 
+    message: string, 
+    isNonFormattedPaste: boolean, 
+    caretPosition?: number, 
+    isInEditMode?: boolean,
+    usersByUsername?: Record<string, any>,
+    teammateNameDisplay?: string,
+) {
     const isKnownTarget = isKnownTargetForPaste(event, location, isInEditMode);
     if (!isKnownTarget || isNonFormattedPaste) {
         return;
@@ -188,7 +198,31 @@ export function pasteHandler(event: ClipboardEvent, location: string, message: s
         return;
     }
 
-    const {selectionStart, selectionEnd} = target as TextboxElement;
+    const {selectionStart: displaySelectionStart, selectionEnd: displaySelectionEnd} = target as TextboxElement;
+
+    // Convert display positions to raw positions
+    const selectionStart = convertDisplayPositionToRawPosition(
+        displaySelectionStart || 0,
+        message,
+        usersByUsername,
+        teammateNameDisplay,
+    );
+    const selectionEnd = convertDisplayPositionToRawPosition(
+        displaySelectionEnd || 0,
+        message,
+        usersByUsername,
+        teammateNameDisplay,
+    );
+
+    // Convert caretPosition from display to raw position if needed
+    const rawCaretPosition = caretPosition !== undefined 
+        ? convertDisplayPositionToRawPosition(
+            caretPosition,
+            message,
+            usersByUsername,
+            teammateNameDisplay,
+        )
+        : undefined;
 
     const hasSelection = !isNil(selectionStart) && !isNil(selectionEnd) && selectionStart < selectionEnd;
     const hasTextUrl = isTextUrl(clipboardData);
@@ -211,7 +245,7 @@ export function pasteHandler(event: ClipboardEvent, location: string, message: s
         const {formattedCodeBlock} = formatGithubCodePaste({selectionStart, selectionEnd, message, clipboardData});
         execCommandInsertText(formattedCodeBlock);
     } else {
-        const {formattedMarkdown} = formatMarkdownMessage(clipboardData, message, caretPosition);
+        const {formattedMarkdown} = formatMarkdownMessage(clipboardData, message, rawCaretPosition);
         execCommandInsertText(formattedMarkdown);
     }
 }


### PR DESCRIPTION
This pull request introduces a robust mapping system between raw and display positions in the advanced text editor, ensuring accurate cursor and selection handling when usernames are replaced with display names. It adds new utility functions for converting between raw and display positions, updates the editor and emoji picker logic to use these conversions, and propagates the necessary user data throughout the relevant components and handlers.

**Core improvements to position mapping and editor logic:**

* Added utility functions `generateDisplayValueFromRawValue`, `convertDisplayPositionToRawPosition`, and `convertRawPositionToDisplayPosition` to `textbox/util.ts` for mapping cursor and selection positions between raw message values and display values, especially when usernames are replaced with display names.
* Updated the advanced text editor (`advanced_text_editor.tsx`) to use these new conversion utilities for selection and caret positioning, ensuring that all cursor movements and selections remain accurate when display names are shown. [[1]](diffhunk://#diff-27f27793c2ebfa9b65632c48487ebe0d11445721a554e55c0c74442e44632b0bL297-R300) [[2]](diffhunk://#diff-27f27793c2ebfa9b65632c48487ebe0d11445721a554e55c0c74442e44632b0bR506-R522) [[3]](diffhunk://#diff-27f27793c2ebfa9b65632c48487ebe0d11445721a554e55c0c74442e44632b0bL703-R730)

**Propagation of user data and conversion logic:**

* Modified hooks and handlers (`use_editor_emoji_picker.tsx`, `use_key_handler.tsx`) to accept and use `usersByUsername` and `teammateNameDisplay` for correct position conversion, and updated logic to use display-to-raw conversions for emoji insertion and key events. [[1]](diffhunk://#diff-507135801b76df81f7b2a1f7a7cce3952b4d27d800d79d2913dcda47897f83abR40-R41) [[2]](diffhunk://#diff-507135801b76df81f7b2a1f7a7cce3952b4d27d800d79d2913dcda47897f83abL66-R81) [[3]](diffhunk://#diff-c8842a3a53949b85c65b9fdd2fc56f333a77c2a33bc65c8a4c9c99f1ae86ea1bR54-R56) [[4]](diffhunk://#diff-c8842a3a53949b85c65b9fdd2fc56f333a77c2a33bc65c8a4c9c99f1ae86ea1bL208-R230)
* Updated paste handling (`paste.tsx`) to convert display selection/caret positions to raw positions using the new utilities and user data, ensuring pasted content is inserted at the correct location regardless of display name substitutions. [[1]](diffhunk://#diff-4191fd77f74595d6cf2bbb91adc2571130ca18070818bba478fdbc3668d6e341L179-R189) [[2]](diffhunk://#diff-4191fd77f74595d6cf2bbb91adc2571130ca18070818bba478fdbc3668d6e341L191-R225)

**Component integration and refactoring:**

* Refactored component props and internal logic to consistently pass and use the necessary user mapping and display preferences for all position-sensitive operations, including formatting bar, emoji picker, and key handlers. [[1]](diffhunk://#diff-27f27793c2ebfa9b65632c48487ebe0d11445721a554e55c0c74442e44632b0bR345-R346) [[2]](diffhunk://#diff-27f27793c2ebfa9b65632c48487ebe0d11445721a554e55c0c74442e44632b0bR456-R458)

These changes together ensure that all cursor, selection, and insertion operations in the editor behave correctly and intuitively, even when the display value differs from the raw value due to username display settings.

## emoji picker
### Before
https://github.com/user-attachments/assets/5fbcffe9-bf6c-4764-a912-34cae5b3709d
### After
https://github.com/user-attachments/assets/d1616a17-5d6a-4705-9b47-8ffa3d7f62ed

## formatting bar
### Before
https://github.com/user-attachments/assets/2b32b4d5-47c3-4870-8aca-aacf79a9c7de
## After
https://github.com/user-attachments/assets/7a7f73b9-dc97-457d-8e0a-af9e13201160

## command + B
### Before
https://github.com/user-attachments/assets/dad9b248-5607-4607-bce4-d3fc1205b3b7

### After
https://github.com/user-attachments/assets/29847d82-e1da-43f3-9878-2b6fd4c8bec4

## Link
### Before
https://github.com/user-attachments/assets/6f3e61d1-cb91-4fe0-b34e-11fafd56b808

### After
https://github.com/user-attachments/assets/0a6e1fa3-d85d-4a53-aed3-cbae41eae343
