### PR TITLE
Fix mention overlay position

### DIFF
--- a/webapp/channels/src/components/__snapshots__/textbox.test.tsx.snap
+++ b/webapp/channels/src/components/__snapshots__/textbox.test.tsx.snap
@@ -21,135 +21,143 @@ exports[`components/TextBox should match snapshot with additional, optional prop
       message="some test text"
     />
   </div>
-  <Connect(SuggestionBox)
-    className="form-control custom-textarea textbox-edit-area custom-textarea--emoji-picker bad-connection"
-    contextId="channelId"
-    disabled={true}
-    id="someid"
-    inputComponent={
-      Object {
-        "$$typeof": Symbol(react.memo),
-        "compare": null,
-        "type": Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "propTypes": Object {
-            "className": [Function],
-            "defaultValue": [Function],
-            "disabled": [Function],
-            "id": [Function],
-            "onChange": [Function],
-            "onHeightChange": [Function],
-            "onInput": [Function],
-            "onWidthChange": [Function],
-            "placeholder": [Function],
-            "value": [Function],
-          },
-          "render": [Function],
-        },
-      }
-    }
-    listComponent={[Function]}
-    listPosition="top"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onComposition={[MockFunction]}
-    onHeightChange={[MockFunction]}
-    onItemSelected={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[MockFunction]}
-    onKeyUp={[Function]}
-    onMouseUp={[Function]}
-    openWhenEmpty={true}
-    placeholder="placeholder text"
-    providers={
-      Array [
-        AtMentionProvider {
-          "addLastViewAtToProfiles": [Function],
-          "autocompleteGroups": Array [
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid1",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid2",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-          ],
-          "autocompleteUsersInChannel": [Function],
-          "channelId": "channelId",
-          "currentUserId": "currentUserId",
-          "data": null,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "getProfilesInChannel": [Function],
-          "lastCompletedWord": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "priorityProfiles": undefined,
-          "requestStarted": false,
-          "searchAssociatedGroupsForReference": [Function],
-          "triggerCharacter": "@",
-          "useChannelMentions": true,
-        },
-        ChannelMentionProvider {
-          "autocompleteChannels": [MockFunction],
-          "delayChannelAutocomplete": false,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "lastCompletedWord": "",
-          "lastPrefixTrimmed": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": "~",
-        },
-        EmoticonProvider {
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": ":",
-        },
-      ]
-    }
-    renderDividers={
-      Array [
-        "all",
-      ]
-    }
-    spellCheck="true"
+  <div
     style={
       Object {
-        "visibility": "hidden",
+        "position": "relative",
       }
     }
-    value="some test text"
-  />
+  >
+    <Connect(SuggestionBox)
+      className="form-control custom-textarea textbox-edit-area custom-textarea--emoji-picker bad-connection"
+      contextId="channelId"
+      disabled={true}
+      id="someid"
+      inputComponent={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "propTypes": Object {
+              "className": [Function],
+              "defaultValue": [Function],
+              "disabled": [Function],
+              "id": [Function],
+              "onChange": [Function],
+              "onHeightChange": [Function],
+              "onInput": [Function],
+              "onWidthChange": [Function],
+              "placeholder": [Function],
+              "value": [Function],
+            },
+            "render": [Function],
+          },
+        }
+      }
+      listComponent={[Function]}
+      listPosition="top"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onComposition={[MockFunction]}
+      onHeightChange={[MockFunction]}
+      onItemSelected={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[MockFunction]}
+      onKeyUp={[Function]}
+      onMouseUp={[Function]}
+      openWhenEmpty={true}
+      placeholder="placeholder text"
+      providers={
+        Array [
+          AtMentionProvider {
+            "addLastViewAtToProfiles": [Function],
+            "autocompleteGroups": Array [
+              Object {
+                "allow_reference": true,
+                "create_at": 1,
+                "delete_at": 0,
+                "description": "",
+                "display_name": "group_display_name",
+                "has_syncables": false,
+                "id": "gid1",
+                "member_count": 0,
+                "name": "group_name",
+                "remote_id": "",
+                "scheme_admin": false,
+                "source": "",
+                "update_at": 1,
+              },
+              Object {
+                "allow_reference": true,
+                "create_at": 1,
+                "delete_at": 0,
+                "description": "",
+                "display_name": "group_display_name",
+                "has_syncables": false,
+                "id": "gid2",
+                "member_count": 0,
+                "name": "group_name",
+                "remote_id": "",
+                "scheme_admin": false,
+                "source": "",
+                "update_at": 1,
+              },
+            ],
+            "autocompleteUsersInChannel": [Function],
+            "channelId": "channelId",
+            "currentUserId": "currentUserId",
+            "data": null,
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "getProfilesInChannel": [Function],
+            "lastCompletedWord": "",
+            "lastPrefixWithNoResults": "",
+            "latestComplete": true,
+            "latestPrefix": "",
+            "priorityProfiles": undefined,
+            "requestStarted": false,
+            "searchAssociatedGroupsForReference": [Function],
+            "triggerCharacter": "@",
+            "useChannelMentions": true,
+          },
+          ChannelMentionProvider {
+            "autocompleteChannels": [MockFunction],
+            "delayChannelAutocomplete": false,
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "lastCompletedWord": "",
+            "lastPrefixTrimmed": "",
+            "lastPrefixWithNoResults": "",
+            "latestComplete": true,
+            "latestPrefix": "",
+            "requestStarted": false,
+            "triggerCharacter": "~",
+          },
+          EmoticonProvider {
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "latestComplete": true,
+            "latestPrefix": "",
+            "requestStarted": false,
+            "triggerCharacter": ":",
+          },
+        ]
+      }
+      renderDividers={
+        Array [
+          "all",
+        ]
+      }
+      spellCheck="true"
+      style={
+        Object {
+          "visibility": "hidden",
+        }
+      }
+      value="some test text"
+    />
+  </div>
 </div>
 `;
 
@@ -174,130 +182,138 @@ exports[`components/TextBox should match snapshot with required props 1`] = `
       message="some test text"
     />
   </div>
-  <Connect(SuggestionBox)
-    className="form-control custom-textarea textbox-edit-area"
-    contextId="channelId"
-    id="someid"
-    inputComponent={
-      Object {
-        "$$typeof": Symbol(react.memo),
-        "compare": null,
-        "type": Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "propTypes": Object {
-            "className": [Function],
-            "defaultValue": [Function],
-            "disabled": [Function],
-            "id": [Function],
-            "onChange": [Function],
-            "onHeightChange": [Function],
-            "onInput": [Function],
-            "onWidthChange": [Function],
-            "placeholder": [Function],
-            "value": [Function],
-          },
-          "render": [Function],
-        },
-      }
-    }
-    listComponent={[Function]}
-    onBlur={[Function]}
-    onChange={[Function]}
-    onItemSelected={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[MockFunction]}
-    onKeyUp={[Function]}
-    onMouseUp={[Function]}
-    placeholder="placeholder text"
-    providers={
-      Array [
-        AtMentionProvider {
-          "addLastViewAtToProfiles": [Function],
-          "autocompleteGroups": Array [
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid1",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid2",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-          ],
-          "autocompleteUsersInChannel": [Function],
-          "channelId": "channelId",
-          "currentUserId": "currentUserId",
-          "data": null,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "getProfilesInChannel": [Function],
-          "lastCompletedWord": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "priorityProfiles": undefined,
-          "requestStarted": false,
-          "searchAssociatedGroupsForReference": [Function],
-          "triggerCharacter": "@",
-          "useChannelMentions": true,
-        },
-        ChannelMentionProvider {
-          "autocompleteChannels": [MockFunction],
-          "delayChannelAutocomplete": false,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "lastCompletedWord": "",
-          "lastPrefixTrimmed": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": "~",
-        },
-        EmoticonProvider {
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": ":",
-        },
-      ]
-    }
-    renderDividers={
-      Array [
-        "all",
-      ]
-    }
-    spellCheck="true"
+  <div
     style={
       Object {
-        "visibility": "visible",
+        "position": "relative",
       }
     }
-    value="some test text"
-  />
+  >
+    <Connect(SuggestionBox)
+      className="form-control custom-textarea textbox-edit-area"
+      contextId="channelId"
+      id="someid"
+      inputComponent={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "propTypes": Object {
+              "className": [Function],
+              "defaultValue": [Function],
+              "disabled": [Function],
+              "id": [Function],
+              "onChange": [Function],
+              "onHeightChange": [Function],
+              "onInput": [Function],
+              "onWidthChange": [Function],
+              "placeholder": [Function],
+              "value": [Function],
+            },
+            "render": [Function],
+          },
+        }
+      }
+      listComponent={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onItemSelected={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[MockFunction]}
+      onKeyUp={[Function]}
+      onMouseUp={[Function]}
+      placeholder="placeholder text"
+      providers={
+        Array [
+          AtMentionProvider {
+            "addLastViewAtToProfiles": [Function],
+            "autocompleteGroups": Array [
+              Object {
+                "allow_reference": true,
+                "create_at": 1,
+                "delete_at": 0,
+                "description": "",
+                "display_name": "group_display_name",
+                "has_syncables": false,
+                "id": "gid1",
+                "member_count": 0,
+                "name": "group_name",
+                "remote_id": "",
+                "scheme_admin": false,
+                "source": "",
+                "update_at": 1,
+              },
+              Object {
+                "allow_reference": true,
+                "create_at": 1,
+                "delete_at": 0,
+                "description": "",
+                "display_name": "group_display_name",
+                "has_syncables": false,
+                "id": "gid2",
+                "member_count": 0,
+                "name": "group_name",
+                "remote_id": "",
+                "scheme_admin": false,
+                "source": "",
+                "update_at": 1,
+              },
+            ],
+            "autocompleteUsersInChannel": [Function],
+            "channelId": "channelId",
+            "currentUserId": "currentUserId",
+            "data": null,
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "getProfilesInChannel": [Function],
+            "lastCompletedWord": "",
+            "lastPrefixWithNoResults": "",
+            "latestComplete": true,
+            "latestPrefix": "",
+            "priorityProfiles": undefined,
+            "requestStarted": false,
+            "searchAssociatedGroupsForReference": [Function],
+            "triggerCharacter": "@",
+            "useChannelMentions": true,
+          },
+          ChannelMentionProvider {
+            "autocompleteChannels": [MockFunction],
+            "delayChannelAutocomplete": false,
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "lastCompletedWord": "",
+            "lastPrefixTrimmed": "",
+            "lastPrefixWithNoResults": "",
+            "latestComplete": true,
+            "latestPrefix": "",
+            "requestStarted": false,
+            "triggerCharacter": "~",
+          },
+          EmoticonProvider {
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "latestComplete": true,
+            "latestPrefix": "",
+            "requestStarted": false,
+            "triggerCharacter": ":",
+          },
+        ]
+      }
+      renderDividers={
+        Array [
+          "all",
+        ]
+      }
+      spellCheck="true"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+      value="some test text"
+    />
+  </div>
 </div>
 `;
 
@@ -322,130 +338,138 @@ exports[`components/TextBox should throw error when new property is too long 1`]
       message="some test text that exceeds char limit"
     />
   </div>
-  <Connect(SuggestionBox)
-    className="form-control custom-textarea textbox-edit-area"
-    contextId="channelId"
-    id="someid"
-    inputComponent={
-      Object {
-        "$$typeof": Symbol(react.memo),
-        "compare": null,
-        "type": Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "propTypes": Object {
-            "className": [Function],
-            "defaultValue": [Function],
-            "disabled": [Function],
-            "id": [Function],
-            "onChange": [Function],
-            "onHeightChange": [Function],
-            "onInput": [Function],
-            "onWidthChange": [Function],
-            "placeholder": [Function],
-            "value": [Function],
-          },
-          "render": [Function],
-        },
-      }
-    }
-    listComponent={[Function]}
-    onBlur={[Function]}
-    onChange={[Function]}
-    onItemSelected={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[MockFunction]}
-    onKeyUp={[Function]}
-    onMouseUp={[Function]}
-    placeholder="placeholder text"
-    providers={
-      Array [
-        AtMentionProvider {
-          "addLastViewAtToProfiles": [Function],
-          "autocompleteGroups": Array [
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid1",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid2",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-          ],
-          "autocompleteUsersInChannel": [Function],
-          "channelId": "channelId",
-          "currentUserId": "currentUserId",
-          "data": null,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "getProfilesInChannel": [Function],
-          "lastCompletedWord": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "priorityProfiles": undefined,
-          "requestStarted": false,
-          "searchAssociatedGroupsForReference": [Function],
-          "triggerCharacter": "@",
-          "useChannelMentions": true,
-        },
-        ChannelMentionProvider {
-          "autocompleteChannels": [MockFunction],
-          "delayChannelAutocomplete": false,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "lastCompletedWord": "",
-          "lastPrefixTrimmed": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": "~",
-        },
-        EmoticonProvider {
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": ":",
-        },
-      ]
-    }
-    renderDividers={
-      Array [
-        "all",
-      ]
-    }
-    spellCheck="true"
+  <div
     style={
       Object {
-        "visibility": "visible",
+        "position": "relative",
       }
     }
-    value="some test text that exceeds char limit"
-  />
+  >
+    <Connect(SuggestionBox)
+      className="form-control custom-textarea textbox-edit-area"
+      contextId="channelId"
+      id="someid"
+      inputComponent={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "propTypes": Object {
+              "className": [Function],
+              "defaultValue": [Function],
+              "disabled": [Function],
+              "id": [Function],
+              "onChange": [Function],
+              "onHeightChange": [Function],
+              "onInput": [Function],
+              "onWidthChange": [Function],
+              "placeholder": [Function],
+              "value": [Function],
+            },
+            "render": [Function],
+          },
+        }
+      }
+      listComponent={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onItemSelected={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[MockFunction]}
+      onKeyUp={[Function]}
+      onMouseUp={[Function]}
+      placeholder="placeholder text"
+      providers={
+        Array [
+          AtMentionProvider {
+            "addLastViewAtToProfiles": [Function],
+            "autocompleteGroups": Array [
+              Object {
+                "allow_reference": true,
+                "create_at": 1,
+                "delete_at": 0,
+                "description": "",
+                "display_name": "group_display_name",
+                "has_syncables": false,
+                "id": "gid1",
+                "member_count": 0,
+                "name": "group_name",
+                "remote_id": "",
+                "scheme_admin": false,
+                "source": "",
+                "update_at": 1,
+              },
+              Object {
+                "allow_reference": true,
+                "create_at": 1,
+                "delete_at": 0,
+                "description": "",
+                "display_name": "group_display_name",
+                "has_syncables": false,
+                "id": "gid2",
+                "member_count": 0,
+                "name": "group_name",
+                "remote_id": "",
+                "scheme_admin": false,
+                "source": "",
+                "update_at": 1,
+              },
+            ],
+            "autocompleteUsersInChannel": [Function],
+            "channelId": "channelId",
+            "currentUserId": "currentUserId",
+            "data": null,
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "getProfilesInChannel": [Function],
+            "lastCompletedWord": "",
+            "lastPrefixWithNoResults": "",
+            "latestComplete": true,
+            "latestPrefix": "",
+            "priorityProfiles": undefined,
+            "requestStarted": false,
+            "searchAssociatedGroupsForReference": [Function],
+            "triggerCharacter": "@",
+            "useChannelMentions": true,
+          },
+          ChannelMentionProvider {
+            "autocompleteChannels": [MockFunction],
+            "delayChannelAutocomplete": false,
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "lastCompletedWord": "",
+            "lastPrefixTrimmed": "",
+            "lastPrefixWithNoResults": "",
+            "latestComplete": true,
+            "latestPrefix": "",
+            "requestStarted": false,
+            "triggerCharacter": "~",
+          },
+          EmoticonProvider {
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "latestComplete": true,
+            "latestPrefix": "",
+            "requestStarted": false,
+            "triggerCharacter": ":",
+          },
+        ]
+      }
+      renderDividers={
+        Array [
+          "all",
+        ]
+      }
+      spellCheck="true"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+      value="some test text that exceeds char limit"
+    />
+  </div>
 </div>
 `;
 
@@ -470,129 +494,137 @@ exports[`components/TextBox should throw error when value is too long 1`] = `
       message="some test text that exceeds char limit"
     />
   </div>
-  <Connect(SuggestionBox)
-    className="form-control custom-textarea textbox-edit-area"
-    contextId="channelId"
-    id="someid"
-    inputComponent={
-      Object {
-        "$$typeof": Symbol(react.memo),
-        "compare": null,
-        "type": Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "propTypes": Object {
-            "className": [Function],
-            "defaultValue": [Function],
-            "disabled": [Function],
-            "id": [Function],
-            "onChange": [Function],
-            "onHeightChange": [Function],
-            "onInput": [Function],
-            "onWidthChange": [Function],
-            "placeholder": [Function],
-            "value": [Function],
-          },
-          "render": [Function],
-        },
-      }
-    }
-    listComponent={[Function]}
-    onBlur={[Function]}
-    onChange={[Function]}
-    onItemSelected={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[MockFunction]}
-    onKeyUp={[Function]}
-    onMouseUp={[Function]}
-    placeholder="placeholder text"
-    providers={
-      Array [
-        AtMentionProvider {
-          "addLastViewAtToProfiles": [Function],
-          "autocompleteGroups": Array [
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid1",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-            Object {
-              "allow_reference": true,
-              "create_at": 1,
-              "delete_at": 0,
-              "description": "",
-              "display_name": "group_display_name",
-              "has_syncables": false,
-              "id": "gid2",
-              "member_count": 0,
-              "name": "group_name",
-              "remote_id": "",
-              "scheme_admin": false,
-              "source": "",
-              "update_at": 1,
-            },
-          ],
-          "autocompleteUsersInChannel": [Function],
-          "channelId": "channelId",
-          "currentUserId": "currentUserId",
-          "data": null,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "getProfilesInChannel": [Function],
-          "lastCompletedWord": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "priorityProfiles": undefined,
-          "requestStarted": false,
-          "searchAssociatedGroupsForReference": [Function],
-          "triggerCharacter": "@",
-          "useChannelMentions": true,
-        },
-        ChannelMentionProvider {
-          "autocompleteChannels": [MockFunction],
-          "delayChannelAutocomplete": false,
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "lastCompletedWord": "",
-          "lastPrefixTrimmed": "",
-          "lastPrefixWithNoResults": "",
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": "~",
-        },
-        EmoticonProvider {
-          "disableDispatches": false,
-          "forceDispatch": false,
-          "latestComplete": true,
-          "latestPrefix": "",
-          "requestStarted": false,
-          "triggerCharacter": ":",
-        },
-      ]
-    }
-    renderDividers={
-      Array [
-        "all",
-      ]
-    }
-    spellCheck="true"
+  <div
     style={
       Object {
-        "visibility": "visible",
+        "position": "relative",
       }
     }
-    value="some test text that exceeds char limit"
-  />
+  >
+    <Connect(SuggestionBox)
+      className="form-control custom-textarea textbox-edit-area"
+      contextId="channelId"
+      id="someid"
+      inputComponent={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "propTypes": Object {
+              "className": [Function],
+              "defaultValue": [Function],
+              "disabled": [Function],
+              "id": [Function],
+              "onChange": [Function],
+              "onHeightChange": [Function],
+              "onInput": [Function],
+              "onWidthChange": [Function],
+              "placeholder": [Function],
+              "value": [Function],
+            },
+            "render": [Function],
+          },
+        }
+      }
+      listComponent={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onItemSelected={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[MockFunction]}
+      onKeyUp={[Function]}
+      onMouseUp={[Function]}
+      placeholder="placeholder text"
+      providers={
+        Array [
+          AtMentionProvider {
+            "addLastViewAtToProfiles": [Function],
+            "autocompleteGroups": Array [
+              Object {
+                "allow_reference": true,
+                "create_at": 1,
+                "delete_at": 0,
+                "description": "",
+                "display_name": "group_display_name",
+                "has_syncables": false,
+                "id": "gid1",
+                "member_count": 0,
+                "name": "group_name",
+                "remote_id": "",
+                "scheme_admin": false,
+                "source": "",
+                "update_at": 1,
+              },
+              Object {
+                "allow_reference": true,
+                "create_at": 1,
+                "delete_at": 0,
+                "description": "",
+                "display_name": "group_display_name",
+                "has_syncables": false,
+                "id": "gid2",
+                "member_count": 0,
+                "name": "group_name",
+                "remote_id": "",
+                "scheme_admin": false,
+                "source": "",
+                "update_at": 1,
+              },
+            ],
+            "autocompleteUsersInChannel": [Function],
+            "channelId": "channelId",
+            "currentUserId": "currentUserId",
+            "data": null,
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "getProfilesInChannel": [Function],
+            "lastCompletedWord": "",
+            "lastPrefixWithNoResults": "",
+            "latestComplete": true,
+            "latestPrefix": "",
+            "priorityProfiles": undefined,
+            "requestStarted": false,
+            "searchAssociatedGroupsForReference": [Function],
+            "triggerCharacter": "@",
+            "useChannelMentions": true,
+          },
+          ChannelMentionProvider {
+            "autocompleteChannels": [MockFunction],
+            "delayChannelAutocomplete": false,
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "lastCompletedWord": "",
+            "lastPrefixTrimmed": "",
+            "lastPrefixWithNoResults": "",
+            "latestComplete": true,
+            "latestPrefix": "",
+            "requestStarted": false,
+            "triggerCharacter": "~",
+          },
+          EmoticonProvider {
+            "disableDispatches": false,
+            "forceDispatch": false,
+            "latestComplete": true,
+            "latestPrefix": "",
+            "requestStarted": false,
+            "triggerCharacter": ":",
+          },
+        ]
+      }
+      renderDividers={
+        Array [
+          "all",
+        ]
+      }
+      spellCheck="true"
+      style={
+        Object {
+          "visibility": "visible",
+        }
+      }
+      value="some test text that exceeds char limit"
+    />
+  </div>
 </div>
 `;

--- a/webapp/channels/src/components/textbox/highlight.tsx
+++ b/webapp/channels/src/components/textbox/highlight.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import {Preferences} from 'mattermost-redux/constants';
 
@@ -14,6 +14,7 @@ const MentionOverlay: React.FC<{
     displayValue: string;
 }> = ({textarea, mentionHighlights, displayValue}) => {
     const overlayRef = useRef<HTMLDivElement>(null);
+    const [scrollPosition, setScrollPosition] = useState({left: 0, top: 0});
 
     useEffect(() => {
         const overlay = overlayRef.current;
@@ -25,8 +26,8 @@ const MentionOverlay: React.FC<{
         overlay.style.position = 'absolute';
         overlay.style.top = '0';
         overlay.style.left = '0';
-        overlay.style.right = '0';
-        overlay.style.bottom = '0';
+        overlay.style.width = '100%';
+        overlay.style.height = '100%';
         overlay.style.pointerEvents = 'none';
         overlay.style.color = 'transparent';
         overlay.style.backgroundColor = 'transparent';
@@ -41,25 +42,19 @@ const MentionOverlay: React.FC<{
         overlay.style.overflowX = 'hidden';
         overlay.style.overflowY = 'hidden';
         overlay.style.zIndex = '1';
-
-        overlay.style.width = `${textarea.clientWidth}px`;
-        overlay.style.height = `${textarea.clientHeight}px`;
+        
         overlay.style.borderRadius = computedStyle.borderRadius;
         overlay.style.boxSizing = computedStyle.boxSizing;
 
         const updatePosition = () => {
-            if (!textarea || !overlay) {
+            if (!textarea) {
                 return;
             }
 
-            overlay.style.transform = `translate(${-textarea.scrollLeft}px, ${-textarea.scrollTop}px)`;
-
-            const newWidth = textarea.clientWidth;
-            const newHeight = textarea.clientHeight;
-            if (overlay.style.width !== `${newWidth}px` || overlay.style.height !== `${newHeight}px`) {
-                overlay.style.width = `${newWidth}px`;
-                overlay.style.height = `${newHeight}px`;
-            }
+            setScrollPosition({
+                left: textarea.scrollLeft,
+                top: textarea.scrollTop,
+            });
         };
 
         updatePosition();
@@ -96,8 +91,21 @@ const MentionOverlay: React.FC<{
         <div
             ref={overlayRef}
             className='mention-overlay'
+            style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                overflow: 'hidden',
+                pointerEvents: 'none',
+            }}
         >
-            {renderHighlightedText(mentionHighlights, displayValue)}
+            <div style={{
+                transform: `translate(${-scrollPosition.left}px, ${-scrollPosition.top}px)`,
+            }}>
+                {renderHighlightedText(mentionHighlights, displayValue)}
+            </div>
         </div>
     );
 };

--- a/webapp/channels/src/components/textbox/highlight.tsx
+++ b/webapp/channels/src/components/textbox/highlight.tsx
@@ -17,7 +17,9 @@ const MentionOverlay: React.FC<{
 
     useEffect(() => {
         const overlay = overlayRef.current;
-        if (!overlay || !textarea) return;
+        if (!overlay || !textarea) {
+            return () => {};
+        }
 
         const computedStyle = window.getComputedStyle(textarea);
         overlay.style.position = 'absolute';
@@ -39,17 +41,19 @@ const MentionOverlay: React.FC<{
         overlay.style.overflowX = 'hidden';
         overlay.style.overflowY = 'hidden';
         overlay.style.zIndex = '1';
-        
+
         overlay.style.width = `${textarea.clientWidth}px`;
         overlay.style.height = `${textarea.clientHeight}px`;
         overlay.style.borderRadius = computedStyle.borderRadius;
         overlay.style.boxSizing = computedStyle.boxSizing;
 
         const updatePosition = () => {
-            if (!textarea || !overlay) return;
-            
+            if (!textarea || !overlay) {
+                return;
+            }
+
             overlay.style.transform = `translate(${-textarea.scrollLeft}px, ${-textarea.scrollTop}px)`;
-            
+
             const newWidth = textarea.clientWidth;
             const newHeight = textarea.clientHeight;
             if (overlay.style.width !== `${newWidth}px` || overlay.style.height !== `${newHeight}px`) {

--- a/webapp/channels/src/components/textbox/highlight.tsx
+++ b/webapp/channels/src/components/textbox/highlight.tsx
@@ -42,7 +42,7 @@ const MentionOverlay: React.FC<{
         overlay.style.overflowX = 'hidden';
         overlay.style.overflowY = 'hidden';
         overlay.style.zIndex = '1';
-        
+
         overlay.style.borderRadius = computedStyle.borderRadius;
         overlay.style.boxSizing = computedStyle.boxSizing;
 
@@ -101,9 +101,11 @@ const MentionOverlay: React.FC<{
                 pointerEvents: 'none',
             }}
         >
-            <div style={{
-                transform: `translate(${-scrollPosition.left}px, ${-scrollPosition.top}px)`,
-            }}>
+            <div
+                style={{
+                    transform: `translate(${-scrollPosition.left}px, ${-scrollPosition.top}px)`,
+                }}
+            >
                 {renderHighlightedText(mentionHighlights, displayValue)}
             </div>
         </div>

--- a/webapp/channels/src/components/textbox/textbox.tsx
+++ b/webapp/channels/src/components/textbox/textbox.tsx
@@ -27,7 +27,7 @@ import {generateMapValueFromInputValue, generateDisplayValueFromMapValue, update
 
 import * as Utils from 'utils/utils';
 
-import {renderMentionOverlay} from './hilight';
+import {renderMentionOverlay} from './highlight';
 
 import type {TextboxElement} from './index';
 

--- a/webapp/channels/src/components/textbox/textbox.tsx
+++ b/webapp/channels/src/components/textbox/textbox.tsx
@@ -396,11 +396,7 @@ export default class Textbox extends React.PureComponent<Props> {
                         alignWithTextbox={this.props.alignWithTextbox}
                         onItemSelected={this.handleSuggestionSelected}
                     />
-                    {!this.props.preview && this.props.isAdvanced && (
-                        <div style={{position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, overflow: 'hidden', pointerEvents: 'none'}}>
-                            {renderMentionOverlay(this.getInputBox(), this.state.mentionHighlights, this.state.displayValue)}
-                        </div>
-                    )}
+                    {!this.props.preview && this.props.isAdvanced && renderMentionOverlay(this.getInputBox(), this.state.mentionHighlights, this.state.displayValue)}
                 </div>
             </div>
         );

--- a/webapp/channels/src/components/textbox/textbox.tsx
+++ b/webapp/channels/src/components/textbox/textbox.tsx
@@ -396,7 +396,11 @@ export default class Textbox extends React.PureComponent<Props> {
                         alignWithTextbox={this.props.alignWithTextbox}
                         onItemSelected={this.handleSuggestionSelected}
                     />
-                    {!this.props.preview && this.props.isAdvanced && renderMentionOverlay(this.getInputBox(), this.state.mentionHighlights, this.state.displayValue)}
+                    {!this.props.preview && this.props.isAdvanced && (
+                        <div style={{position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, overflow: 'hidden', pointerEvents: 'none'}}>
+                            {renderMentionOverlay(this.getInputBox(), this.state.mentionHighlights, this.state.displayValue)}
+                        </div>
+                    )}
                 </div>
             </div>
         );

--- a/webapp/channels/src/components/textbox/textbox.tsx
+++ b/webapp/channels/src/components/textbox/textbox.tsx
@@ -363,39 +363,45 @@ export default class Textbox extends React.PureComponent<Props> {
                         imageProps={{hideUtilities: true}}
                     />
                 </div>
-                <SuggestionBox
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
-                    ref={this.message}
-                    id={this.props.id}
-                    className={textboxClassName}
-                    spellCheck='true'
-                    placeholder={this.props.createMessage}
-                    onChange={this.handleChange}
-                    onKeyPress={this.props.onKeyPress}
-                    onKeyDown={this.handleKeyDown}
-                    onMouseUp={this.handleMouseUp}
-                    onKeyUp={this.handleKeyUp}
-                    onComposition={this.props.onComposition}
-                    onBlur={this.handleBlur}
-                    onFocus={this.props.onFocus}
-                    onHeightChange={this.props.onHeightChange}
-                    onWidthChange={this.props.onWidthChange}
-                    onPaste={this.props.onPaste}
-                    style={this.getStyle()}
-                    inputComponent={this.props.inputComponent}
-                    listComponent={this.props.suggestionList}
-                    listPosition={this.props.suggestionListPosition}
-                    providers={this.suggestionProviders}
-                    value={this.props.isAdvanced ? this.state.displayValue : this.props.value}
-                    renderDividers={ALL}
-                    disabled={this.props.disabled}
-                    contextId={this.props.channelId}
-                    openWhenEmpty={this.props.openWhenEmpty}
-                    alignWithTextbox={this.props.alignWithTextbox}
-                    onItemSelected={this.handleSuggestionSelected}
-                />
-                {!this.props.preview && renderMentionOverlay(this.getInputBox(), this.state.mentionHighlights, this.state.displayValue)}
+                <div style={{position: 'relative'}}>
+                    <SuggestionBox
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore
+                        ref={this.message}
+                        id={this.props.id}
+                        className={textboxClassName}
+                        spellCheck='true'
+                        placeholder={this.props.createMessage}
+                        onChange={this.handleChange}
+                        onKeyPress={this.props.onKeyPress}
+                        onKeyDown={this.handleKeyDown}
+                        onMouseUp={this.handleMouseUp}
+                        onKeyUp={this.handleKeyUp}
+                        onComposition={this.props.onComposition}
+                        onBlur={this.handleBlur}
+                        onFocus={this.props.onFocus}
+                        onHeightChange={this.props.onHeightChange}
+                        onWidthChange={this.props.onWidthChange}
+                        onPaste={this.props.onPaste}
+                        style={this.getStyle()}
+                        inputComponent={this.props.inputComponent}
+                        listComponent={this.props.suggestionList}
+                        listPosition={this.props.suggestionListPosition}
+                        providers={this.suggestionProviders}
+                        value={this.props.isAdvanced ? this.state.displayValue : this.props.value}
+                        renderDividers={ALL}
+                        disabled={this.props.disabled}
+                        contextId={this.props.channelId}
+                        openWhenEmpty={this.props.openWhenEmpty}
+                        alignWithTextbox={this.props.alignWithTextbox}
+                        onItemSelected={this.handleSuggestionSelected}
+                    />
+                    {!this.props.preview && this.props.isAdvanced && (
+                        <div style={{position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, overflow: 'hidden', pointerEvents: 'none'}}>
+                            {renderMentionOverlay(this.getInputBox(), this.state.mentionHighlights, this.state.displayValue)}
+                        </div>
+                    )}
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
This pull request introduces a new mention overlay feature for the text box component, improving the user experience by visually highlighting mentions as users type. The overlay is carefully positioned and styled to follow the textarea's scroll and resize events, and is only rendered in advanced mode. Additionally, some unused date suggestion UI code has been commented out.

**Mention Overlay Feature:**

* Added a new `MentionOverlay` React component in `hilight.tsx` that visually highlights mentions and synchronizes its position and styling with the underlying textarea, including scroll and resize handling.
* Updated the `renderMentionOverlay` function to use the new `MentionOverlay` component when the element is a textarea, and to handle both textarea and preview div elements.
* Modified `Textbox` (`textbox.tsx`) to wrap the suggestion box and mention overlay in a relatively positioned container, and to render the overlay only in advanced mode and when not in preview. [[1]](diffhunk://#diff-6e6cab79c1bbdc06aac7081a3998c19aed90ac2b29b2d2b64ac643d4d5f9c247R366) [[2]](diffhunk://#diff-6e6cab79c1bbdc06aac7081a3998c19aed90ac2b29b2d2b64ac643d4d5f9c247L398-R404)

**Code Cleanup:**

* Commented out unused date suggestion UI code in the `SuggestionBox` component (`suggestion_box.jsx`). [[1]](diffhunk://#diff-f8ca2dcdce58c750019ee3659f18577a47aa6b5f3e966aafb8cba239e74e6e12L855-R855) [[2]](diffhunk://#diff-f8ca2dcdce58c750019ee3659f18577a47aa6b5f3e966aafb8cba239e74e6e12L865-R865)

## Scroll
### Before
https://github.com/user-attachments/assets/fa6de6e6-5c9b-4284-8368-a7b9c962bf26
### After
https://github.com/user-attachments/assets/ce5eebd4-ebb8-490b-af03-cf775812900d

## Scroll & mention
### Before
https://github.com/user-attachments/assets/b7aa4e8b-cb58-449c-b9e3-5b40764c3604

### After
https://github.com/user-attachments/assets/6a63cfa6-8f32-427d-ab4e-c0730230ffff



