### PR TITLE
Add channel integration functionality for official channel detection

### DIFF
--- a/server/channels/app/channel_integration.go
+++ b/server/channels/app/channel_integration.go
@@ -44,8 +44,11 @@ func (a *App) IsOfficialChannel(c request.CTX, channel *model.Channel) (bool, *m
 
 	creatorUser, err := a.GetUser(channel.CreatorId)
 	if err != nil {
-		// If creator user doesn't exist, channel is not official
-		return false, nil
+		if err.StatusCode == http.StatusNotFound {
+			// If creator user doesn't exist, channel is not official
+			return false, nil
+		}
+		return false, err
 	}
 
 	return creatorUser.Username == adminUsername, nil

--- a/server/channels/app/channel_integration.go
+++ b/server/channels/app/channel_integration.go
@@ -44,7 +44,7 @@ func (a *App) IsOfficialChannel(c request.CTX, channel *model.Channel) (bool, *m
 
 	creatorUser, err := a.GetUser(channel.CreatorId)
 	if err != nil {
-		if err.StatusCode == http.StatusNotFound {
+		if err.Id == MissingAccountError {
 			// If creator user doesn't exist, channel is not official
 			return false, nil
 		}

--- a/server/channels/app/channel_integration.go
+++ b/server/channels/app/channel_integration.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"os"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+)
+
+// IsOfficialTunagChannel checks if a channel is official by comparing creator with integration admin user.
+func (a *App) IsOfficialTunagChannel(c request.CTX, channel *model.Channel) (bool, *model.AppError) {
+	if channel == nil {
+		return false, nil
+	}
+
+	integrationAdminUsername := os.Getenv("INTEGRATION_ADMIN_USERNAME")
+	if integrationAdminUsername == "" {
+		return false, nil
+	}
+
+	creatorUser, err := a.GetUser(channel.CreatorId)
+	if err != nil {
+		return false, err
+	}
+
+	if creatorUser == nil {
+		return false, nil
+	}
+
+	return creatorUser.Username == integrationAdminUsername, nil
+}

--- a/server/channels/app/channel_integration.go
+++ b/server/channels/app/channel_integration.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"net/http"
 	"os"
 	"sync"
 
@@ -28,13 +29,17 @@ func getIntegrationAdminUsername() string {
 // IsOfficialChannel checks if a channel is official by comparing creator with integration admin user.
 func (a *App) IsOfficialChannel(c request.CTX, channel *model.Channel) (bool, *model.AppError) {
 	if channel == nil {
-		return false, nil
+		return false, model.NewAppError("IsOfficialChannel", "app.channel.invalid", nil, "channel is nil", http.StatusBadRequest)
+	}
+
+	if channel.CreatorId == "" {
+		return false, model.NewAppError("IsOfficialChannel", "app.channel.invalid_creator", nil, "channel creator ID is empty", http.StatusBadRequest)
 	}
 
 	// Get cached integration admin username
 	adminUsername := getIntegrationAdminUsername()
 	if adminUsername == "" {
-		return false, nil
+		return false, model.NewAppError("IsOfficialChannel", "app.channel.config_missing", nil, "INTEGRATION_ADMIN_USERNAME not configured", http.StatusInternalServerError)
 	}
 
 	creatorUser, err := a.GetUser(channel.CreatorId)

--- a/server/channels/app/channel_integration.go
+++ b/server/channels/app/channel_integration.go
@@ -33,7 +33,7 @@ func (a *App) IsOfficialChannel(c request.CTX, channel *model.Channel) (bool, *m
 	}
 
 	if channel.CreatorId == "" {
-		return false, model.NewAppError("IsOfficialChannel", "app.channel.invalid_creator", nil, "channel creator ID is empty", http.StatusBadRequest)
+		return false, nil
 	}
 
 	// Get cached integration admin username
@@ -44,7 +44,8 @@ func (a *App) IsOfficialChannel(c request.CTX, channel *model.Channel) (bool, *m
 
 	creatorUser, err := a.GetUser(channel.CreatorId)
 	if err != nil {
-		return false, err
+		// If creator user doesn't exist, channel is not official
+		return false, nil
 	}
 
 	return creatorUser.Username == adminUsername, nil

--- a/server/channels/app/channel_integration_test.go
+++ b/server/channels/app/channel_integration_test.go
@@ -112,8 +112,8 @@ func TestIsOfficialChannel(t *testing.T) {
 	})
 
 	t.Run("returns error when channel is nil", func(t *testing.T) {
-		adminUsername := fmt.Sprintf("integration-admin-%d", time.Now().UnixNano())
-		os.Setenv("INTEGRATION_ADMIN_USERNAME", adminUsername)
+		// Reset cache for this test
+		resetIntegrationAdminUsernameForTesting()
 
 		isOfficial, appErr := th.App.IsOfficialChannel(th.Context, nil)
 		require.NotNil(t, appErr)
@@ -196,17 +196,6 @@ func TestIsOfficialChannel(t *testing.T) {
 		// Reset cache for this test
 		resetIntegrationAdminUsernameForTesting()
 
-		adminUsername := fmt.Sprintf("integration-admin-%d", time.Now().UnixNano())
-		os.Setenv("INTEGRATION_ADMIN_USERNAME", adminUsername)
-
-		// Create admin user (even though it won't be used for DM)
-		_, err := th.App.CreateUser(th.Context, &model.User{
-			Email:    fmt.Sprintf("admin-%d@example.com", time.Now().UnixNano()),
-			Username: adminUsername,
-			Password: "password123",
-		})
-		require.Nil(t, err)
-
 		channel := &model.Channel{
 			Type:      model.ChannelTypeDirect,
 			CreatorId: "", // DM channels typically have empty CreatorId
@@ -220,17 +209,6 @@ func TestIsOfficialChannel(t *testing.T) {
 	t.Run("returns false for GM channel", func(t *testing.T) {
 		// Reset cache for this test
 		resetIntegrationAdminUsernameForTesting()
-
-		adminUsername := fmt.Sprintf("integration-admin-%d", time.Now().UnixNano())
-		os.Setenv("INTEGRATION_ADMIN_USERNAME", adminUsername)
-
-		// Create admin user (even though it won't be used for GM)
-		_, err := th.App.CreateUser(th.Context, &model.User{
-			Email:    fmt.Sprintf("admin-%d@example.com", time.Now().UnixNano()),
-			Username: adminUsername,
-			Password: "password123",
-		})
-		require.Nil(t, err)
 
 		channel := &model.Channel{
 			Type:      model.ChannelTypeGroup,

--- a/server/channels/app/channel_integration_test.go
+++ b/server/channels/app/channel_integration_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+func TestIsOfficialChannel(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	// Save original environment variable
+	originalValue := os.Getenv("INTEGRATION_ADMIN_USERNAME")
+	defer func() {
+		if originalValue == "" {
+			os.Unsetenv("INTEGRATION_ADMIN_USERNAME")
+		} else {
+			os.Setenv("INTEGRATION_ADMIN_USERNAME", originalValue)
+		}
+	}()
+
+	t.Run("returns true when channel creator is integration admin", func(t *testing.T) {
+		// Set up environment variable with unique username
+		adminUsername := fmt.Sprintf("integration-admin-%d", time.Now().UnixNano())
+		os.Setenv("INTEGRATION_ADMIN_USERNAME", adminUsername)
+
+		// Create admin user
+		adminUser, err := th.App.CreateUser(th.Context, &model.User{
+			Email:    fmt.Sprintf("admin-%d@example.com", time.Now().UnixNano()),
+			Username: adminUsername,
+			Password: "password123",
+		})
+		require.Nil(t, err)
+
+		// Create channel with admin user as creator
+		channel := &model.Channel{
+			TeamId:      th.BasicTeam.Id,
+			DisplayName: "Official Channel",
+			Name:        "official-channel",
+			Type:        model.ChannelTypeOpen,
+			CreatorId:   adminUser.Id,
+		}
+
+		isOfficial, appErr := th.App.IsOfficialTunagChannel(th.Context, channel)
+		require.Nil(t, appErr)
+		assert.True(t, isOfficial)
+	})
+
+	t.Run("returns false when channel creator is not integration admin", func(t *testing.T) {
+		// Set up environment variable with unique username
+		adminUsername := fmt.Sprintf("integration-admin-%d", time.Now().UnixNano())
+		os.Setenv("INTEGRATION_ADMIN_USERNAME", adminUsername)
+
+		// Use basic user (not admin) as creator
+		channel := &model.Channel{
+			TeamId:      th.BasicTeam.Id,
+			DisplayName: "Non-Official Channel",
+			Name:        "non-official-channel",
+			Type:        model.ChannelTypeOpen,
+			CreatorId:   th.BasicUser.Id,
+		}
+
+		isOfficial, appErr := th.App.IsOfficialTunagChannel(th.Context, channel)
+		require.Nil(t, appErr)
+		assert.False(t, isOfficial)
+	})
+
+	t.Run("returns false when environment variable is not set", func(t *testing.T) {
+		// Clear environment variable
+		os.Unsetenv("INTEGRATION_ADMIN_USERNAME")
+
+		channel := &model.Channel{
+			TeamId:      th.BasicTeam.Id,
+			DisplayName: "Test Channel",
+			Name:        "test-channel",
+			Type:        model.ChannelTypeOpen,
+			CreatorId:   th.BasicUser.Id,
+		}
+
+		isOfficial, appErr := th.App.IsOfficialTunagChannel(th.Context, channel)
+		require.Nil(t, appErr)
+		assert.False(t, isOfficial)
+	})
+
+	t.Run("returns false when channel is nil", func(t *testing.T) {
+		adminUsername := fmt.Sprintf("integration-admin-%d", time.Now().UnixNano())
+		os.Setenv("INTEGRATION_ADMIN_USERNAME", adminUsername)
+
+		isOfficial, appErr := th.App.IsOfficialTunagChannel(th.Context, nil)
+		require.Nil(t, appErr)
+		assert.False(t, isOfficial)
+	})
+
+	t.Run("returns error when user does not exist", func(t *testing.T) {
+		adminUsername := fmt.Sprintf("integration-admin-%d", time.Now().UnixNano())
+		os.Setenv("INTEGRATION_ADMIN_USERNAME", adminUsername)
+
+		channel := &model.Channel{
+			TeamId:      th.BasicTeam.Id,
+			DisplayName: "Test Channel",
+			Name:        "test-channel",
+			Type:        model.ChannelTypeOpen,
+			CreatorId:   "non-existent-user-id",
+		}
+
+		isOfficial, appErr := th.App.IsOfficialTunagChannel(th.Context, channel)
+		require.NotNil(t, appErr)
+		assert.False(t, isOfficial)
+	})
+
+	t.Run("returns false when environment variable is empty string", func(t *testing.T) {
+		// Set environment variable to empty string
+		os.Setenv("INTEGRATION_ADMIN_USERNAME", "")
+
+		channel := &model.Channel{
+			TeamId:      th.BasicTeam.Id,
+			DisplayName: "Test Channel",
+			Name:        "test-channel",
+			Type:        model.ChannelTypeOpen,
+			CreatorId:   th.BasicUser.Id,
+		}
+
+		isOfficial, appErr := th.App.IsOfficialTunagChannel(th.Context, channel)
+		require.Nil(t, appErr)
+		assert.False(t, isOfficial)
+	})
+
+	t.Run("works with different channel types", func(t *testing.T) {
+		adminUsername := fmt.Sprintf("integration-admin-%d", time.Now().UnixNano())
+		os.Setenv("INTEGRATION_ADMIN_USERNAME", adminUsername)
+
+		// Create admin user
+		adminUser, err := th.App.CreateUser(th.Context, &model.User{
+			Email:    fmt.Sprintf("admin-%d@example.com", time.Now().UnixNano()),
+			Username: adminUsername,
+			Password: "password123",
+		})
+		require.Nil(t, err)
+
+		// Test with private channel
+		privateChannel := &model.Channel{
+			TeamId:      th.BasicTeam.Id,
+			DisplayName: "Private Official Channel",
+			Name:        "private-official-channel",
+			Type:        model.ChannelTypePrivate,
+			CreatorId:   adminUser.Id,
+		}
+
+		isOfficial, appErr := th.App.IsOfficialTunagChannel(th.Context, privateChannel)
+		require.Nil(t, appErr)
+		assert.True(t, isOfficial)
+	})
+}


### PR DESCRIPTION
## Overview
This PR implements a solution for GitHub issue #523 by adding channel integration functionality to determine if a channel is an official TUNAG channel.

## Changes
- **New file**: `server/channels/app/channel_integration.go`
  - Implements `IsOfficialChannel` function
  - Uses `INTEGRATION_ADMIN_USERNAME` environment variable for official channel detection
  - Follows Mattermost app layer architecture patterns

- **New file**: `server/channels/app/channel_integration_test.go`
  - Comprehensive test suite with 7 test cases
  - Tests normal operation, edge cases, and error conditions
  - Uses Mattermost testing patterns with Setup(t).InitBasic()

## Issues Resolved
- **[#523](https://github.com/stmninc/tunag-chat/issues/523)**: Create a common function to determine if a channel is an official channel
  - `IsOfficialChannel` function provides official channel detection capability

## Technical Details
- Direct environment variable access using `os.Getenv` following existing Mattermost patterns
- File naming follows Mattermost conventions (similar to channel.go, integration_action.go)
- Proper error handling for missing users and nil channels
- Test coverage includes unique username generation to avoid conflicts

## Testing
All tests pass successfully:
- Normal operation with valid environment variable
- Edge cases with empty environment variable
- Error handling for missing users and nil channels
- Different channel types (public, private, direct message, group message)