### PR TITLE
Fix: Remove hyphen from special search characters to support username

### DIFF
--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -350,7 +350,6 @@ func (ss *SqlStore) specialSearchChars() []string {
 		"<",
 		">",
 		"+",
-		"-",
 		"(",
 		")",
 		"~",


### PR DESCRIPTION
## Summary

This PR fixes a design contradiction in the codebase where usernames containing hyphens could not be searched accurately in Recent Mentions feature.

**Problem:**
- Username validation allows hyphens: `^[a-z0-9\.\-_]+$` (in `user.go`)
- Search functionality treats hyphens as special characters (in `store.go`)
- Result: Valid usernames like `user-123` cannot be found in Recent Mentions

**Solution:**
- Removed hyphen (`"-"`) from the `specialSearchChars()` function in `SqlStore`
- This allows usernames with hyphens to be searched accurately without breaking existing functionality

**Impact:**
- Users can now search for usernames containing hyphens in Recent Mentions
- All existing tests pass - no regression in search functionality
- Resolves the design contradiction between username validation and search processing

## Ticket Link

https://github.com/stmninc/tunag-chat/issues/354

## Screenshots

NA

## Release Note

```release-note
Fixed an issue where usernames containing hyphens could