### PR TITLE
Improving Branch References and Staging Builds for Custom CI Artifacts

### DIFF
--- a/.github/workflows/custom-ci-artifacts.yml
+++ b/.github/workflows/custom-ci-artifacts.yml
@@ -15,6 +15,14 @@ on:
         description: 'Tag to build'
         required: false
         default: ''
+      environment:
+        description: 'Environment to build (production or staging)'
+        required: false
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - staging
 
 jobs:
   build-artifacts:
@@ -95,7 +103,12 @@ jobs:
       - name: Set Docker tags
         id: docker_meta
         run: |
-          IMAGE_NAME="${{ secrets.GAR_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GAR_REPOSITORY_NAME }}/${{ secrets.GAR_IMAGE_NAME }}"
+          if [[ "${{ inputs.environment }}" == "staging" ]]; then
+            GAR_REPOSITORY_NAME="${{ secrets.STG_GAR_REPOSITORY_NAME }}"
+          else
+            GAR_REPOSITORY_NAME="${{ secrets.GAR_REPOSITORY_NAME }}"
+          fi
+          IMAGE_NAME="${{ secrets.GAR_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${GAR_REPOSITORY_NAME}/${{ secrets.GAR_IMAGE_NAME }}"
           DOCKER_TAG_NAME=""
 
           # Priority order for determining the Docker tag name:


### PR DESCRIPTION
This pull request updates the custom CI workflow configuration to improve flexibility and environment targeting. The main change is the addition of an `environment` input to the workflow, allowing builds to be customized for production or staging. The workflow logic is adjusted to use this new input when determining Docker image repository names and tags, and the previous support for selecting a branch during workflow dispatch has been removed.

**Workflow input and logic updates:**

* Added a new `environment` input to the workflow dispatch options, allowing users to select between `production` and `staging` environments when triggering the workflow.
* Removed the `branch` input from workflow dispatch, simplifying the selection logic to rely on tags only.
* Updated the `ref` logic in the checkout steps to only use the `tag` input (if provided), removing support for branch selection. [[1]](diffhunk://#diff-a978d42a146dfe9171bd15c0a5695763dfd8b6fbefcfaabd855a999b8ca8a752L33-R37) [[2]](diffhunk://#diff-a978d42a146dfe9171bd15c0a5695763dfd8b6fbefcfaabd855a999b8ca8a752L84-R88)

**Environment-specific Docker image handling:**

* Modified the Docker image repository selection logic to use a different repository name if the `environment` input is set to `staging`, enabling environment-specific artifact publishing.
* I created tow repositries.
  * [mattermost-repo](https://console.cloud.google.com/artifacts/docker/prefab-orbit-419907/asia-northeast1/mattermost-repo?hl=ja&inv=1&invt=Abkn8A&project=prefab-orbit-419907)
  * [staging-mattermost-repo](https://console.cloud.google.com/artifacts/docker/prefab-orbit-419907/asia-northeast1/staging-mattermost-repo?hl=ja&inv=1&invt=Abkn8A&project=prefab-orbit-419907)  ※ New