### PR TITLE
fix: Use NewMatchPhraseQuery when term is mention

### DIFF
--- a/server/platform/services/searchengine/bleveengine/search.go
+++ b/server/platform/services/searchengine/bleveengine/search.go
@@ -167,6 +167,11 @@ func (b *BleveEngine) SearchPosts(channels model.ChannelList, searchParams []*mo
 						messageQ := bleve.NewWildcardQuery(term)
 						messageQ.SetField("Message")
 						termQueries = append(termQueries, messageQ)
+					} else if len(term) >= 4 && term[0] == '"' && term[len(term)-1] == '"' && strings.HasPrefix(term[1:], "@") && strings.Contains(term, "-") {
+						unquotedTerm := term[1 : len(term)-1]
+						messageQ := bleve.NewMatchPhraseQuery(unquotedTerm)
+						messageQ.SetField("Message")
+						termQueries = append(termQueries, messageQ)
 					} else {
 						terms = append(terms, term)
 					}


### PR DESCRIPTION
This pull request introduces a targeted improvement to the search functionality in the Bleve search engine integration. Specifically, it adds support for a new type of search query that recognizes quoted terms starting with `@` and containing a `-`, treating them as phrase matches.

Enhancement to search query handling:

* Added logic to detect terms that are quoted, start with `@`, and contain a `-`, then process them using a `MatchPhraseQuery` on the `Message` field for more accurate phrase matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved search accuracy for quoted mentions containing hyphens (e.g., "@user-group"). These terms are now treated as exact phrases when enclosed in quotes, preventing unintended wildcard matching and returning more precise results.
  - Other search term behaviors remain unchanged, ensuring consistent results for existing queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->