### PR TITLE
feat: add isOfficialTunagChannel function

### DIFF
--- a/webapp/channels/src/utils/official_channel_utils.test.ts
+++ b/webapp/channels/src/utils/official_channel_utils.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Channel} from '@mattermost/types/channels';
+
+import * as OfficialChannelUtils from 'utils/official_channel_utils';
+
+describe('Official Channel Utils', () => {
+    describe('isOfficialTunagChannel', () => {
+        test('returns true for valid official tunag channel names', () => {
+            // Test with channel name string
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-stmn-admin')).toBe(true);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-12345-abc-admin')).toBe(true);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-0-z-admin')).toBe(true);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-999-company123-admin')).toBe(true);
+        });
+
+        test('returns true for valid official tunag channel objects', () => {
+            // Test with channel object
+            const validChannel: Partial<Channel> = {
+                name: 'tunag-00002-stmn-admin',
+                id: 'channel_id',
+                display_name: 'Official Channel',
+            };
+
+            expect(OfficialChannelUtils.isOfficialTunagChannel(validChannel as Channel)).toBe(true);
+        });
+
+        test('returns false for invalid official tunag channel names', () => {
+            // Missing components
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-admin')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-admin')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-stmn-admin')).toBe(false);
+
+            // Wrong prefix
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunagg-00002-stmn-admin')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tuna-00002-stmn-admin')).toBe(false);
+
+            // Wrong suffix
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-stmn-admins')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-stmn-user')).toBe(false);
+
+            // Non-numeric company id
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-abc-stmn-admin')).toBe(false);
+
+            // Extra characters or spacing
+            expect(OfficialChannelUtils.isOfficialTunagChannel(' tunag-00002-stmn-admin')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-stmn-admin ')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-stmn-admin-extra')).toBe(false);
+
+            // Empty or undefined values
+            expect(OfficialChannelUtils.isOfficialTunagChannel('')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('regular-channel')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('random-channel-name')).toBe(false);
+        });
+
+        test('returns false for channels with empty or undefined names', () => {
+            const channelWithoutName: Partial<Channel> = {
+                id: 'channel_id',
+                display_name: 'Some Channel',
+            };
+
+            const channelWithEmptyName: Partial<Channel> = {
+                name: '',
+                id: 'channel_id',
+                display_name: 'Some Channel',
+            };
+
+            expect(OfficialChannelUtils.isOfficialTunagChannel(channelWithoutName as Channel)).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel(channelWithEmptyName as Channel)).toBe(false);
+        });
+
+        test('handles edge cases correctly', () => {
+            // Test various valid patterns
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-1-a-admin')).toBe(true);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-123456789-subdomain123-admin')).toBe(true);
+
+            // Test invalid patterns with special characters
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-stm-n-admin')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-stm_n-admin')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-stm.n-admin')).toBe(false);
+
+            // Test case sensitivity
+            expect(OfficialChannelUtils.isOfficialTunagChannel('TUNAG-00002-stmn-admin')).toBe(false);
+            expect(OfficialChannelUtils.isOfficialTunagChannel('tunag-00002-stmn-ADMIN')).toBe(false);
+        });
+    });
+});

--- a/webapp/channels/src/utils/official_channel_utils.ts
+++ b/webapp/channels/src/utils/official_channel_utils.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Channel} from '@mattermost/types/channels';
+
+/**
+ * Check if a channel is an official tunag channel based on its name pattern.
+ * Official channels follow the pattern: tunag-{company_id}-{subdomain}-admin
+ * Example: tunag-00002-stmn-admin
+ * Pattern: tunag-digits-alphanumeric-admin
+ *
+ * @param {Channel | string} channel - Channel object or channel name string
+ * @returns {boolean} - true if channel is an official tunag channel, false otherwise
+ */
+export function isOfficialTunagChannel(channel: Channel | string): boolean {
+    const channelName = typeof channel === 'string' ? channel : channel.name;
+
+    if (!channelName) {
+        return false;
+    }
+
+    // Pattern: tunag-{digits}-{alphanumeric}-admin
+    // Example: tunag-00002-stmn-admin
+    const officialChannelPattern = /^tunag-\d+-[a-zA-Z0-9]+-admin$/;
+
+    return officialChannelPattern.test(channelName);
+}


### PR DESCRIPTION
### Summary
Implements issue #530 - Create a common function to determine if a channel is official

Added a new utility function isOfficialTunagChannel that detects official tunag channels based on the pattern tunag-digits-alphanumeric-admin (e.g., tunag-00002-stmn-admin).

The function:
- Returns boolean value for channel validation
- Supports both Channel objects and string inputs  
- Created in a separate file to avoid conflicts
- Includes comprehensive test coverage

### Ticket Link
https://github.com/stmninc/tunag-chat/issues/530

### Screenshots
N/A - Backend utility function

### Release Note
Added isOfficialTunagChannel utility function to detect official tunag channels