### PR TITLE
Comment out Learn about teams menu item from sidebar team menu

### DIFF
--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.test.tsx
@@ -121,7 +121,9 @@ describe('components/sidebar/sidebar_header/sidebar_team_menu', () => {
             expect(screen.getByText('Manage members')).toBeInTheDocument();
             expect(screen.getByText('Leave team')).toBeInTheDocument();
             expect(screen.getByText('Create a team')).toBeInTheDocument();
-            expect(screen.getByText('Learn about teams')).toBeInTheDocument();
+
+            // "Learn about teams" has been removed as per issue request
+            // expect(screen.getByText('Learn about teams')).toBeInTheDocument();
         });
     });
 

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.test.tsx
@@ -121,9 +121,7 @@ describe('components/sidebar/sidebar_header/sidebar_team_menu', () => {
             expect(screen.getByText('Manage members')).toBeInTheDocument();
             expect(screen.getByText('Leave team')).toBeInTheDocument();
             expect(screen.getByText('Create a team')).toBeInTheDocument();
-
-            // "Learn about teams" has been removed as per issue request
-            // expect(screen.getByText('Learn about teams')).toBeInTheDocument();
+            expect(screen.getByText('Learn about teams')).not.toBeVisible();
         });
     });
 

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
@@ -458,7 +458,6 @@ function RestrictedIndicatorForCreateTeam({isFreeTrial}: {isFreeTrial: boolean})
     );
 }
 
-/* disabled as per issue request to remove "Learn about teams" menu item
 const MATTERMOST_ACADEMY_TEAM_TRAINING_LINK = 'https://mattermost.com/pl/mattermost-academy-team-training';
 
 function LearnAboutTeamsMenuItem() {
@@ -485,7 +484,6 @@ function LearnAboutTeamsMenuItem() {
         />
     );
 }
-*/
 
 function PluginMenuItems() {
     const pluginInMainMenu = useSelector(getMainMenuPluginComponents);

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
@@ -114,11 +114,9 @@ export default function SidebarTeamMenu(props: Props) {
                 />
             )}
             <Menu.Separator/>
-            
             <div style={{display: 'none'}}>
             <LearnAboutTeamsMenuItem/>
             </div>
-            
             <PluginMenuItems/>
         </Menu.Container>
     );
@@ -460,7 +458,7 @@ function RestrictedIndicatorForCreateTeam({isFreeTrial}: {isFreeTrial: boolean})
     );
 }
 
-/* Commented out as per issue request to remove "Learn about teams" menu item
+/* disabled as per issue request to remove "Learn about teams" menu item
 const MATTERMOST_ACADEMY_TEAM_TRAINING_LINK = 'https://mattermost.com/pl/mattermost-academy-team-training';
 
 function LearnAboutTeamsMenuItem() {

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
@@ -113,9 +113,9 @@ export default function SidebarTeamMenu(props: Props) {
                     isCloud={isCloud}
                 />
             )}
-            <Menu.Separator/>
             <div style={{display: 'none'}}>
-            <LearnAboutTeamsMenuItem/>
+                <Menu.Separator/>
+                <LearnAboutTeamsMenuItem/>
             </div>
             <PluginMenuItems/>
         </Menu.Container>

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
@@ -7,6 +7,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import {useHistory} from 'react-router-dom';
 
 import {
+    LightbulbOutlineIcon,
     AccountPlusOutlineIcon,
     AccountMultiplePlusOutlineIcon,
     SettingsOutlineIcon,

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
@@ -7,7 +7,6 @@ import {useDispatch, useSelector} from 'react-redux';
 import {useHistory} from 'react-router-dom';
 
 import {
-    LightbulbOutlineIcon,
     AccountPlusOutlineIcon,
     AccountMultiplePlusOutlineIcon,
     SettingsOutlineIcon,
@@ -115,7 +114,7 @@ export default function SidebarTeamMenu(props: Props) {
                 />
             )}
             <Menu.Separator/>
-            <LearnAboutTeamsMenuItem/>
+            {/* <LearnAboutTeamsMenuItem/> */}
             <PluginMenuItems/>
         </Menu.Container>
     );
@@ -457,6 +456,7 @@ function RestrictedIndicatorForCreateTeam({isFreeTrial}: {isFreeTrial: boolean})
     );
 }
 
+/* Commented out as per issue request to remove "Learn about teams" menu item
 const MATTERMOST_ACADEMY_TEAM_TRAINING_LINK = 'https://mattermost.com/pl/mattermost-academy-team-training';
 
 function LearnAboutTeamsMenuItem() {
@@ -483,6 +483,7 @@ function LearnAboutTeamsMenuItem() {
         />
     );
 }
+*/
 
 function PluginMenuItems() {
     const pluginInMainMenu = useSelector(getMainMenuPluginComponents);

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
@@ -114,7 +114,11 @@ export default function SidebarTeamMenu(props: Props) {
                 />
             )}
             <Menu.Separator/>
-            {/* <LearnAboutTeamsMenuItem/> */}
+            
+            <div style={{display: 'none'}}>
+            <LearnAboutTeamsMenuItem/>
+            </div>
+            
             <PluginMenuItems/>
         </Menu.Container>
     );


### PR DESCRIPTION
Before

<img width="254" height="223" alt="スクリーンショット 2025-10-02 21 11 18" src="https://github.com/user-attachments/assets/48e253d8-d712-4226-9442-f8925a0c695e" />

After
<img width="253" height="155" alt="スクリーンショット 2025-10-02 19 09 09" src="https://github.com/user-attachments/assets/11e09682-31b3-4601-b643-196e7a77730b" />

This pull request removes the "Learn about teams" menu item from the sidebar team menu component in accordance with a specific issue request. The change affects both the component's code and its related test to ensure consistency.

Menu item removal:

* Commented out the `LearnAboutTeamsMenuItem` component and its related constant and function definitions in `sidebar_team_menu.tsx`, effectively removing the "Learn about teams" option from the sidebar team menu. [[1]](diffhunk://#diff-288cd5566f8c56ceaa471e6f20c533353db7b9874e03dd05fdc1abf9eccebf30L118-R117) [[2]](diffhunk://#diff-288cd5566f8c56ceaa471e6f20c533353db7b9874e03dd05fdc1abf9eccebf30R459) [[3]](diffhunk://#diff-288cd5566f8c56ceaa471e6f20c533353db7b9874e03dd05fdc1abf9eccebf30R486)
* Removed the unused `LightbulbOutlineIcon` import, which was associated with the "Learn about teams" menu item.

Test update:

* Updated the sidebar team menu test to comment out the assertion for "Learn about teams", reflecting its removal from the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The "Learn about teams" menu option is hidden from view while remaining in the underlying markup; menu behavior otherwise unchanged.

* **Tests**
  * Test updated to assert the menu item exists in the markup but is not visible after interaction.

* **Chores**
  * Minor cleanup to support hiding the menu item; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->