### PR TITLE
Hide "Learn about teams" button & separator from UI

### DIFF
--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.test.tsx
@@ -121,7 +121,7 @@ describe('components/sidebar/sidebar_header/sidebar_team_menu', () => {
             expect(screen.getByText('Manage members')).toBeInTheDocument();
             expect(screen.getByText('Leave team')).toBeInTheDocument();
             expect(screen.getByText('Create a team')).toBeInTheDocument();
-            expect(screen.getByText('Learn about teams')).toBeInTheDocument();
+            expect(screen.getByText('Learn about teams')).not.toBeVisible();
         });
     });
 

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_team_menu.tsx
@@ -114,8 +114,10 @@ export default function SidebarTeamMenu(props: Props) {
                     isCloud={isCloud}
                 />
             )}
-            <Menu.Separator/>
-            <LearnAboutTeamsMenuItem/>
+            <div style={{display: 'none'}}>
+                <Menu.Separator/>
+                <LearnAboutTeamsMenuItem/>
+            </div>
             <PluginMenuItems/>
         </Menu.Container>
     );


### PR DESCRIPTION
Before
<img width="275" height="341" alt="image" src="https://github.com/user-attachments/assets/e57809e6-40be-459b-a9c0-e1cbe26668ab" />

After
<img width="270" height="295" alt="image" src="https://github.com/user-attachments/assets/4dfcba5a-b032-4f3f-8051-c89de5290623" />


----the following summary is generated by copilot------

This pull request updates the visibility of the "Learn about teams" menu item in the sidebar team menu component. The menu item is now hidden from view, and the related test has been updated to reflect this change.

**UI changes:**

* Wrapped the `LearnAboutTeamsMenuItem` in a `div` with `display: none` in `sidebar_team_menu.tsx` to hide the menu item from the UI.

**Test updates:**

* Changed the test in `sidebar_team_menu.test.tsx` to check that "Learn about teams" is not visible, rather than present in the document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Hid the “Learn about teams” option and its separator in the sidebar team menu, removing them from view without altering other menu items.

* **Tests**
  * Updated tests to validate that the “Learn about teams” item is present but not visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->