### PR TITLE
Removed EnableDiagnostics when Sentry reporting configuration

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -274,7 +274,7 @@ func NewServer(options ...Option) (*Server, error) {
 	// below this. Otherwise, please add it to Channels struct in app/channels.go.
 	// -------------------------------------------------------------------------
 
-	if *s.platform.Config().LogSettings.EnableDiagnostics && *s.platform.Config().LogSettings.EnableSentry {
+	if *s.platform.Config().LogSettings.EnableSentry {
 		switch model.GetServiceEnvironment() {
 		case model.ServiceEnvironmentDev:
 			mlog.Warn("Sentry reporting is enabled, but service environment is dev. Disabling reporting.")
@@ -868,7 +868,7 @@ func (s *Server) Start() error {
 
 	switch model.GetServiceEnvironment() {
 	case model.ServiceEnvironmentProduction, model.ServiceEnvironmentTest:
-		if *s.platform.Config().LogSettings.EnableDiagnostics && *s.platform.Config().LogSettings.EnableSentry {
+		if *s.platform.Config().LogSettings.EnableSentry {
 			sentryHandler := sentryhttp.New(sentryhttp.Options{
 				Repanic: true,
 			})


### PR DESCRIPTION
Sentryを動かすために環境変数EnableDiagnosticsと環境変数EnableSentryが両方ともtrueになっていなければならなかったところ、EnableDiagnosticsを消去して、環境変数EnableSentryのみがtrueになっていればSentryが動くように変更しました。

以下で理由を述べます。前提として、環境変数EnableDiagnosticsは現状falseで設定されています。さらに、SentryだけではなくTelemetry機能（Mattermost本部にステータスなどを送る機能；使いたくない機能）においてもこの環境変数が使用されています。そのため、Sentryを動かす目的で環境変数EnableDiagnosticsをtrueに設定し動かしたくない機能であるTelemetry機能が動くようになってしまうよりかは、Sentryを動かす条件として環境変数EnableSentryのみにした方が良いと判断しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sentry error reporting now activates solely based on the Sentry setting, no longer tied to the global diagnostics setting. This makes configuration behavior predictable: enabling Sentry consistently captures errors; disabling it fully prevents reporting. Note: deployments with Sentry enabled but diagnostics disabled will now send error reports. Review your settings to ensure they reflect your intended telemetry preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->