### PR TITLE
[TEST] fix: add customize assets target

### DIFF
--- a/.github/workflows/custom-ci-artifacts.yml
+++ b/.github/workflows/custom-ci-artifacts.yml
@@ -60,9 +60,14 @@ jobs:
         run: make setup-go-work
 
       - name: Build
+        env:
+          CUSTOM_JP_PLATFORM_NAME: ${{ vars.CUSTOM_JP_PLATFORM_NAME }}
+          CUSTOM_PLATFORM_NAME: ${{ vars.CUSTOM_PLATFORM_NAME }}
+          CUSTOM_SERVICE_NAME: ${{ vars.CUSTOM_SERVICE_NAME }}
         run: |
           make config-reset
           make build-cmd BUILD_NUMBER='${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}'
+          make customize-assets
           make package BUILD_NUMBER='${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}'
 
       # In server-ci-artifacts.yml, this step uploads the artifacts to S3.

--- a/server/build/custom-release.mk
+++ b/server/build/custom-release.mk
@@ -1,0 +1,33 @@
+# $(DIST_PATH) is the distribution root directory defined in server/Makefile
+# This target customizes files under $(DIST_PATH)/client/
+
+# Throw an error if $(DIST_PATH) is not set
+ifndef DIST_PATH
+$(error DIST_PATH is not set. Please run this Makefile via server/Makefile or set DIST_PATH manually)
+endif
+
+customize-assets:
+	# Replace strings using variables
+	sed -i '' -e '/"about\.notice"/!{ /"about\.copyright"/!s/Mattermost/$(CUSTOM_JP_PLATFORM_NAME)/g; }' $(DIST_PATH)/client/i18n/ja.*.json || true
+	sed -i '' -e 's/GitLab/$(CUSTOM_SERVICE_NAME)/g' -e 's/{service}/$(CUSTOM_SERVICE_NAME)/g' -e '/"about\.notice"/!{ /"about\.copyright"/!s/Mattermost/$(CUSTOM_PLATFORM_NAME)/g; }' $(DIST_PATH)/client/i18n/*.json || true
+	sed -i '' -e 's/Mattermost/$(CUSTOM_JP_PLATFORM_NAME)/g' $(DIST_PATH)/client/i18n/ja.json || true
+	sed -i '' -e 's/{{.Service}}/$(CUSTOM_SERVICE_NAME)/g' -e 's/Mattermost/$(CUSTOM_PLATFORM_NAME)/g' $(DIST_PATH)/client/i18n/*.json || true
+
+	# Remove GitLab icon from login screen
+	icon_str='"svg",{width:"[0-9]\+",height:"[0-9]\+",viewBox:"0 0 [0-9]\+ [0-9]\+",fill:"none",xmlns:"http:\/\/www.w3.org\/2000\/svg","aria-label":t({id:"generic_icons.login.gitlab",defaultMessage:"Gitlab Icon"})}'
+	file=$$(grep -l $${icon_str} $(DIST_PATH)/client/*.js || true)
+	if [ -n "$$file" ]; then \
+		sed -i '' "s|$${icon_str}|\"span\",{}|g" "$$file"; \
+		sed -i '' "s/external-login-button-label//g" "$$file"; \
+	fi
+
+	# Hide Mattermost logo at the top left (before login)
+	hfroute_header='o().createElement("div",{className:c()("hfroute-header",{"has-free-banner":r,"has-custom-site-name":b})}'
+	file_hfroute_header=$$(grep -l "$${hfroute_header}" $(DIST_PATH)/client/*.js || true)
+	if [ -n "$$file_hfroute_header" ]; then \
+		hidden_hfroute_header='o().createElement("div",{className:c()("hfroute-header",{"has-free-banner":r,"has-custom-site-name":b}),style:{visibility:"hidden"}}'; \
+		sed -i '' "s|$${hfroute_header}|$${hidden_hfroute_header}|g" "$$file_hfroute_header"; \
+	fi
+
+	# Hide loading screen icon
+	echo ".LoadingAnimation__compass { display: none; }" >> $(DIST_PATH)/client/css/initial_loading_screen.css


### PR DESCRIPTION
This pull request introduces a new customization step to the CI build pipeline, allowing for dynamic branding and asset modifications in the client distribution. The main changes center around the addition of a `customize-assets` make target, which updates localized strings, removes specific icons, and hides branding elements based on environment variables. This enhances the ability to generate custom-branded releases automatically.

**Build pipeline enhancements:**

* Added environment variables (`CUSTOM_JP_PLATFORM_NAME`, `CUSTOM_PLATFORM_NAME`, `CUSTOM_SERVICE_NAME`) to the CI workflow and inserted a new `make customize-assets` step in `.github/workflows/custom-ci-artifacts.yml` to support dynamic branding during the build process.

**Asset customization logic:**

* Introduced the `customize-assets` target in `server/build/custom-release.mk`, which:
  * Updates localized JSON files to replace branding strings with custom names using environment variables.
  * Removes the GitLab icon from the login screen by detecting and replacing its SVG markup in built client JS files.
  * Hides the Mattermost logo in the header before login by modifying the relevant JS code to set its visibility to hidden.
  * Hides the loading screen icon by appending a CSS rule to the client’s loading screen stylesheet.
  * Ensures the customization step only runs if `DIST_PATH` is set, with an error if not.