### PR TITLE
Add panic trigger for Sentry testing

### DIFF
--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -81,6 +81,11 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	post.SanitizeInput()
 	post.UserId = c.AppContext.Session().UserId
 
+	// TODO: Remove this panic trigger for local Sentry testing
+	// if post.Message == "trigger panic" {
+	// 	panic("Test panic for Sentry - triggered by 'trigger panic' message")
+	// }
+
 	auditRec := c.MakeAuditRecord(model.AuditEventCreatePost, model.AuditStatusFail)
 	defer c.LogAuditRecWithLevel(auditRec, app.LevelContent)
 	model.AddEventParameterAuditableToAuditRec(auditRec, "post", &post)

--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -82,9 +82,9 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	post.UserId = c.AppContext.Session().UserId
 
 	// TODO: Remove this panic trigger for local Sentry testing
-	// if post.Message == "trigger panic" {
-	// 	panic("Test panic for Sentry - triggered by 'trigger panic' message")
-	// }
+	if post.Message == "trigger panic" {
+	panic("Test panic for Sentry - triggered by 'trigger panic' message")
+	}
 
 	auditRec := c.MakeAuditRecord(model.AuditEventCreatePost, model.AuditStatusFail)
 	defer c.LogAuditRecWithLevel(auditRec, app.LevelContent)

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -85,7 +85,7 @@ const (
 	debugScheduledPostJobInterval = 2 * time.Second
 )
 
-var SentryDSN = "https://04337f87f1ff7e0031b9be256ee99535@o4510146945548288.ingest.us.sentry.io/4510147136389120"
+var SentryDSN = "https://c7c9dceea6665652d4b3512e3b2b1ba8@o4510146945548288.ingest.us.sentry.io/4510164601470976"
 
 // This is a placeholder to allow the existing release pipelines to run without failing to insert
 // the key that's now hard-coded above. Remove this once we converge on the unified delivery
@@ -274,11 +274,16 @@ func NewServer(options ...Option) (*Server, error) {
 	// below this. Otherwise, please add it to Channels struct in app/channels.go.
 	// -------------------------------------------------------------------------
 
+	// mlog.Debug("Sentry configuration during server initialization",
+	// mlog.Bool("EnableSentry", *s.platform.Config().LogSettings.EnableSentry),
+	// mlog.String("ServiceEnvironment", string(model.GetServiceEnvironment())))
+
 	if *s.platform.Config().LogSettings.EnableSentry {
 		switch model.GetServiceEnvironment() {
 		case model.ServiceEnvironmentDev:
-			mlog.Warn("Sentry reporting is enabled, but service environment is dev. Disabling reporting.")
+			// mlog.Warn("Sentry reporting is enabled, but service environment is dev. Disabling reporting.")
 		case model.ServiceEnvironmentProduction, model.ServiceEnvironmentTest:
+			// mlog.Info("Initializing Sentry for error tracking")
 			if err2 := sentry.Init(sentry.ClientOptions{
 				Dsn:              SentryDSN,
 				Release:          model.BuildHash,
@@ -298,7 +303,10 @@ func NewServer(options ...Option) (*Server, error) {
 					return 0.0
 				}),
 			}); err2 != nil {
-				mlog.Warn("Sentry could not be initiated, probably bad DSN?", mlog.Err(err2))
+				// mlog.Warn("Sentry could not be initiated, probably bad DSN?", mlog.Err(err2))
+			} else {
+				// mlog.Info("Sentry initialized successfully",
+				// mlog.String("Release", model.BuildHash))
 			}
 		}
 	}
@@ -866,15 +874,22 @@ func (s *Server) Start() error {
 
 	var handler http.Handler = s.RootRouter
 
+	// mlog.Info("Configuring HTTP handler with Sentry middleware",
+	// mlog.Bool("EnableSentry", *s.platform.Config().LogSettings.EnableSentry),
+	// mlog.String("ServiceEnvironment", string(model.GetServiceEnvironment())))
+
 	switch model.GetServiceEnvironment() {
 	case model.ServiceEnvironmentProduction, model.ServiceEnvironmentTest:
 		if *s.platform.Config().LogSettings.EnableSentry {
+			// mlog.Info("Attaching Sentry HTTP handler")
 			sentryHandler := sentryhttp.New(sentryhttp.Options{
 				Repanic: true,
 			})
 			handler = sentryHandler.Handle(handler)
+			// mlog.Info("Sentry HTTP handler attached successfully")
 		}
 	case model.ServiceEnvironmentDev:
+		// mlog.Debug("Skipping Sentry HTTP handler in development environment")
 	}
 
 	if allowedOrigins := *s.platform.Config().ServiceSettings.AllowCorsFrom; allowedOrigins != "" {

--- a/server/channels/web/web.go
+++ b/server/channels/web/web.go
@@ -4,11 +4,16 @@
 package web
 
 import (
+	// "errors"
+	// "fmt"
 	"net/http"
 	"path"
 	"strings"
 
+	// "time"
+
 	"github.com/avct/uasurfer"
+	// "github.com/getsentry/sentry-go"
 	"github.com/gorilla/mux"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -33,6 +38,7 @@ func New(srv *app.Server) *Web {
 	web.InitOAuth()
 	web.InitWebhooks()
 	web.InitSaml()
+	// web.SetupTestSentryRoute()
 	web.InitStatic()
 
 	return web
@@ -109,3 +115,28 @@ func ReturnStatusOK(w http.ResponseWriter) {
 		mlog.Warn("Error writing status OK response", mlog.Err(err))
 	}
 }
+
+// func (w *Web) SetupTestSentryRoute() {
+// w.MainRouter.HandleFunc("/test_sentry", handleTestSentry).Methods("GET")
+// }
+
+// func handleTestSentry(responseWriter http.ResponseWriter, request *http.Request) {
+// Sentryにテストメッセージを送信
+// eventID1 := sentry.CaptureMessage("Test message from Mattermost web endpoint")
+// mlog.Info("Captured Sentry message", mlog.String("event_id", string(*eventID1)))
+
+// テストエラーを作成して送信
+// testError := errors.New("Test error for Sentry verification")
+// eventID2 := sentry.CaptureException(testError)
+// mlog.Info("Captured Sentry exception", mlog.String("event_id", string(*eventID2)))
+
+// 重要: Sentryにイベントを強制的に送信
+// if sentry.Flush(2 * time.Second) {
+// mlog.Info("Sentry events flushed successfully")
+// } else {
+// mlog.Warn("Failed to flush Sentry events")
+// }
+
+// responseWriter.WriteHeader(http.StatusOK)
+// responseWriter.Write([]byte(fmt.Sprintf("Test data sent to Sentry! Event IDs: %s, %s", *eventID1, *eventID2)))
+// }


### PR DESCRIPTION
このPRはSentryを利用したエラー検知をローカル環境で行うことができたので、mainと比較するために作成したものです。

具体的な変更点としては、

・環境変数チェック目的のデバッグ用のコードを追加（全てコメントアウト済み）
・テスト目的でSentryにエラーを送信するコードを追加（全てコメントアウト済み）
・実際にエラーを起こした際にSentryに通知されるかをチェックするためのエラー発生コード（panic triggerを含めたメッセージを送るとパニックが起きる）を追加（こちらのみコメントアウトを外してあります）

以上の3点です。

現状mainではSentryが動作しないと思われるため、このPRのコードと比較することによってなぜmainのコードでSentryが動作しないのかを明らかにすることができるはずです。逆に言えば、こちらがステージング環境等で正常にエラー検知できた場合はmainは問題なく、単にエラーが起きていないだけの可能性が高くなります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated error-reporting endpoint and reduced runtime diagnostic logging for monitoring.
  * Added non-executing scaffolding for optional monitoring routes; no immediate runtime impact.

* **Bug Fixes / Behavior**
  * Posting the exact message "trigger panic" will now cause a runtime crash during post creation; this can affect stability and error reporting.

* **Notes**
  * Monitoring initialization failures are now quieter; fewer startup warnings are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->