### PR TITLE
feat: add auto-tag workflow for release branch merges

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,157 @@
+name: Auto Tag on Release Branch Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'release-*'
+
+jobs:
+  auto-tag:
+    # Only run if PR was merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      
+      - name: Extract tag from PR
+        id: extract-tag
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          echo "PR Title: $PR_TITLE"
+          echo "PR Body: $PR_BODY"
+          
+          # Pattern to match version tags like v10.9.4-custom-v1.8
+          # Try to find tag in title first
+          TAG=$(echo "$PR_TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_-]+)*' | head -1)
+          
+          # If not found in title, try body
+          if [ -z "$TAG" ]; then
+            TAG=$(echo "$PR_BODY" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9_-]+)*' | head -1)
+          fi
+          
+          if [ -z "$TAG" ]; then
+            echo "No tag found in PR title or body"
+            echo "should_tag=false" >> $GITHUB_OUTPUT
+            echo "tag=" >> $GITHUB_OUTPUT
+          else
+            echo "Found tag: $TAG"
+            echo "should_tag=true" >> $GITHUB_OUTPUT
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Check if tag already exists
+        if: steps.extract-tag.outputs.should_tag == 'true'
+        id: check-tag
+        run: |
+          TAG="${{ steps.extract-tag.outputs.tag }}"
+          
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+            echo "tag_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag $TAG does not exist"
+            echo "tag_exists=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Create tag
+        if: steps.extract-tag.outputs.should_tag == 'true' && steps.check-tag.outputs.tag_exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.extract-tag.outputs.tag }}"
+          COMMIT_SHA="${{ github.event.pull_request.merge_commit_sha }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          MERGED_BY="${{ github.event.pull_request.merged_by.login }}"
+
+          # Sanitize PR_TITLE to escape double quotes and newlines
+          SAFE_PR_TITLE=$(printf "%s" "$PR_TITLE" | sed 's/"/\\"/g' | tr '\n' ' ')
+          
+          # Create annotated tag with metadata
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          TAG_MESSAGE="Release $TAG
+          
+          Merged from PR #$PR_NUMBER: $SAFE_PR_TITLE
+          PR URL: $PR_URL
+          Merged by: $MERGED_BY
+          Commit: $COMMIT_SHA"
+          
+          git tag -a "$TAG" -m "$TAG_MESSAGE" "$COMMIT_SHA"
+          git push origin "$TAG"
+          
+          echo "Created and pushed tag: $TAG"
+      
+      - name: Create release (optional)
+        if: steps.extract-tag.outputs.should_tag == 'true' && steps.check-tag.outputs.tag_exists == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.extract-tag.outputs.tag }}';
+            const prNumber = context.payload.pull_request.number;
+            const prTitle = context.payload.pull_request.title;
+            const prUrl = context.payload.pull_request.html_url;
+            const mergedBy = context.payload.pull_request.merged_by.login;
+            
+            try {
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: `Release ${tag}`,
+                body: `## ${prTitle}\n\nMerged from PR #${prNumber}\n- PR: ${prUrl}\n- Merged by: @${mergedBy}\n\nThis release was automatically created by the auto-tag workflow.`,
+                draft: false,
+                prerelease: /-(alpha|beta|rc|dev)\b/i.test(tag),
+              });
+              console.log('Created release for tag: ' + tag);
+            } catch (error) {
+              console.log('Could not create release: ' + error.message);
+              // Don't fail the workflow if release creation fails
+            }
+      
+      - name: Comment on PR
+        if: steps.extract-tag.outputs.should_tag == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.extract-tag.outputs.tag }}';
+            const tagExists = '${{ steps.check-tag.outputs.tag_exists }}' === 'true';
+            
+            let body;
+            if (tagExists) {
+              body = `Tag \`${tag}\` already exists. No new tag was created.`;
+            } else {
+              body = `Automatically created tag \`${tag}\` for this merge.`;
+            }
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: body
+            });
+      
+      - name: No tag found notification
+        if: steps.extract-tag.outputs.should_tag == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: 'No version tag found in PR title or description. To automatically create a tag, include a version tag (e.g., `v10.9.4-custom-v1.8`) in the PR title or description.'
+            });


### PR DESCRIPTION
## Overview

Adds automation to create tags when PRs are merged to release branches.

## Features

- Automatically extracts version tags from PR title or body
- Creates annotated tags with PR metadata
- Creates GitHub releases (prerelease for tags with hyphens)
- Notifies PR with success/failure comments
- Prevents duplicate tag creation

## How to Use

1. Create a PR to a release branch (e.g., `release-10.9`)
2. Include version tag in PR title or description (e.g., `v10.9.4-custom-v1.8`)
3. Merge the PR
4. Tag and release are automatically created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release versioning workflow to streamline release management when pull requests are merged to release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->