### PR TITLE
Modified the full-text search implementation to be compatible with pg_bigm

### DIFF
--- a/server/channels/api4/file_test.go
+++ b/server/channels/api4/file_test.go
@@ -1440,7 +1440,8 @@ func TestSearchFilesInTeam(t *testing.T) {
 	fileInfos2, _, err := client.SearchFilesWithParams(context.Background(), th.BasicTeam.Id, &searchParams)
 	require.NoError(t, err)
 	// We don't support paging for DB search yet, modify this when we do.
-	require.Len(t, fileInfos2.Order, 3, "Wrong number of fileInfos")
+	// Modified to support pagination within likesearch(), which replaces search().
+	require.Len(t, fileInfos2.Order, 2, "Wrong number of fileInfos")
 	assert.Equal(t, fileInfos.Order[0], fileInfos2.Order[0])
 	assert.Equal(t, fileInfos.Order[1], fileInfos2.Order[1])
 
@@ -1455,7 +1456,8 @@ func TestSearchFilesInTeam(t *testing.T) {
 	fileInfos2, _, err = client.SearchFilesWithParams(context.Background(), th.BasicTeam.Id, &searchParams)
 	require.NoError(t, err)
 	// We don't support paging for DB search yet, modify this when we do.
-	require.Empty(t, fileInfos2.Order, "Wrong number of fileInfos")
+	// Modified to support pagination within likesearch(), which replaces search().
+	assert.Equal(t, fileInfos.Order[2], fileInfos2.Order[0])
 
 	fileInfos, _, err = client.SearchFiles(context.Background(), th.BasicTeam.Id, "search", false)
 	require.NoError(t, err)

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -3910,7 +3910,8 @@ func TestSearchPosts(t *testing.T) {
 	posts2, _, err := client.SearchPostsWithParams(context.Background(), th.BasicTeam.Id, &searchParams)
 	require.NoError(t, err)
 	// We don't support paging for DB search yet, modify this when we do.
-	require.Len(t, posts2.Order, 3, "Wrong number of posts")
+	// Modified to support pagination within likesearch(), which replaces search().
+	require.Len(t, posts2.Order, 2, "Wrong number of posts")
 	assert.Equal(t, posts.Order[0], posts2.Order[0])
 	assert.Equal(t, posts.Order[1], posts2.Order[1])
 
@@ -3925,7 +3926,8 @@ func TestSearchPosts(t *testing.T) {
 	posts2, _, err = client.SearchPostsWithParams(context.Background(), th.BasicTeam.Id, &searchParams)
 	require.NoError(t, err)
 	// We don't support paging for DB search yet, modify this when we do.
-	require.Empty(t, posts2.Order, "Wrong number of posts")
+	// Modified to support pagination within likesearch(), which replaces search().
+	assert.Equal(t, posts.Order[2], posts2.Order[0])
 
 	posts, _, err = client.SearchPosts(context.Background(), th.BasicTeam.Id, "search", false)
 	require.NoError(t, err)

--- a/server/channels/app/file_test.go
+++ b/server/channels/app/file_test.go
@@ -515,6 +515,8 @@ func TestSearchFilesInTeamForUser(t *testing.T) {
 	}
 
 	t.Run("should return everything as first page of fileInfos from database", func(t *testing.T) {
+		// Pagination is supported within likesearch(), alternative to search()
+		t.Skip()
 		th, fileInfos := setup(t, false)
 		defer th.TearDown()
 
@@ -536,6 +538,8 @@ func TestSearchFilesInTeamForUser(t *testing.T) {
 	})
 
 	t.Run("should not return later pages of fileInfos from database", func(t *testing.T) {
+		// Pagination is supported within likesearch(), alternative to search()
+		t.Skip()
 		th, _ := setup(t, false)
 		defer th.TearDown()
 
@@ -608,6 +612,8 @@ func TestSearchFilesInTeamForUser(t *testing.T) {
 	})
 
 	t.Run("should fall back to database if ElasticSearch fails on first page", func(t *testing.T) {
+		// Pagination is supported within likesearch(), alternative to search()
+		t.Skip()
 		th, fileInfos := setup(t, true)
 		defer th.TearDown()
 
@@ -641,6 +647,8 @@ func TestSearchFilesInTeamForUser(t *testing.T) {
 	})
 
 	t.Run("should return nothing if ElasticSearch fails on later pages", func(t *testing.T) {
+		// Pagination is supported within likesearch(), alternative to search()
+		t.Skip()
 		th, _ := setup(t, true)
 		defer th.TearDown()
 

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -1824,6 +1824,8 @@ func TestSearchPostsForUser(t *testing.T) {
 	}
 
 	t.Run("should return everything as first page of posts from database", func(t *testing.T) {
+		// Pagination is supported within likesearch(), alternative to search()
+		t.Skip()
 		mainHelper.Parallel(t)
 		th, posts := setup(t, false)
 		defer th.TearDown()
@@ -1845,6 +1847,8 @@ func TestSearchPostsForUser(t *testing.T) {
 	})
 
 	t.Run("should not return later pages of posts from database", func(t *testing.T) {
+		// Pagination is supported within likesearch(), alternative to search()
+		t.Skip()
 		mainHelper.Parallel(t)
 		th, _ := setup(t, false)
 		defer th.TearDown()
@@ -1917,6 +1921,8 @@ func TestSearchPostsForUser(t *testing.T) {
 	})
 
 	t.Run("should fall back to database if ElasticSearch fails on first page", func(t *testing.T) {
+		// Pagination is supported within likesearch(), alternative to search()
+		t.Skip()
 		mainHelper.Parallel(t)
 		th, posts := setup(t, true)
 		defer th.TearDown()
@@ -1950,6 +1956,8 @@ func TestSearchPostsForUser(t *testing.T) {
 	})
 
 	t.Run("should return nothing if ElasticSearch fails on later pages", func(t *testing.T) {
+		// Pagination is supported within likesearch(), alternative to search()
+		t.Skip()
 		mainHelper.Parallel(t)
 		th, _ := setup(t, true)
 		defer th.TearDown()

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -285,3 +285,5 @@ channels/db/migrations/postgres/100001_add_voipdeviceid_column.down.sql
 channels/db/migrations/postgres/100001_add_voipdeviceid_column.up.sql
 channels/db/migrations/postgres/100002_add_pg_bigm_extension.down.sql
 channels/db/migrations/postgres/100002_add_pg_bigm_extension.up.sql
+channels/db/migrations/postgres/100003_create_index_for_posts_and_fileinfo_using_pgbigm.down.sql
+channels/db/migrations/postgres/100003_create_index_for_posts_and_fileinfo_using_pgbigm.up.sql

--- a/server/channels/db/migrations/postgres/100003_create_index_for_posts_and_fileinfo_using_pgbigm.down.sql
+++ b/server/channels/db/migrations/postgres/100003_create_index_for_posts_and_fileinfo_using_pgbigm.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_posts_message_lower;
+DROP INDEX IF EXISTS idx_posts_hashtags_lower;
+DROP INDEX IF EXISTS idx_fileinfo_name_lower;
+DROP INDEX IF EXISTS idx_fileinfo_content_lower;

--- a/server/channels/db/migrations/postgres/100003_create_index_for_posts_and_fileinfo_using_pgbigm.up.sql
+++ b/server/channels/db/migrations/postgres/100003_create_index_for_posts_and_fileinfo_using_pgbigm.up.sql
@@ -1,0 +1,5 @@
+-- CONCURRENTLY cannot be used because morph runs migrations inside a transaction, which causes failure.
+CREATE INDEX IF NOT EXISTS idx_posts_message_lower ON posts USING gin (LOWER(message) gin_bigm_ops);
+CREATE INDEX IF NOT EXISTS idx_posts_hashtags_lower ON posts USING gin (LOWER(hashtags) gin_bigm_ops);
+CREATE INDEX IF NOT EXISTS idx_fileinfo_name_lower ON fileinfo USING gin (LOWER(name) gin_bigm_ops);
+CREATE INDEX IF NOT EXISTS idx_fileinfo_content_lower ON fileinfo USING gin (LOWER(content) gin_bigm_ops);

--- a/server/channels/store/searchtest/file_info_layer.go
+++ b/server/channels/store/searchtest/file_info_layer.go
@@ -129,6 +129,8 @@ var searchFileInfoStoreTests = []searchTest{
 		Name: "Should discard a wildcard if it's not placed immediately by text",
 		Fn:   testFileInfoSearchDiscardWildcardAlone,
 		Tags: []string{EngineAll},
+		// LIKE search for pg_bigm does not distinguish between exact matches and partial matches in this test case.
+		Skip: true,
 	},
 	{
 		Name: "Should support terms with dash",

--- a/server/channels/store/searchtest/post_layer.go
+++ b/server/channels/store/searchtest/post_layer.go
@@ -39,6 +39,8 @@ var searchPostStoreTests = []searchTest{
 		Name: "Should be able to search without stemming",
 		Fn:   testStemming,
 		Tags: []string{EnginePostgres},
+		// LIKE search for pg_bigm does not support simple search configuration and stemming processing in this test.
+		Skip: true,
 	},
 	{
 		// Postgres supports search with and without quotes
@@ -121,6 +123,8 @@ var searchPostStoreTests = []searchTest{
 		Name: "Should be able to ignore stop words",
 		Fn:   testSearchIgnoringStopWords,
 		Tags: []string{EngineElasticSearch},
+		// LIKE search for pg_bigm does not consider stop words.
+		Skip: true,
 	},
 	{
 		Name: "Should support search stemming",
@@ -141,6 +145,8 @@ var searchPostStoreTests = []searchTest{
 		Name: "Should discard a wildcard if it's not placed immediately by text",
 		Fn:   testSearchDiscardWildcardAlone,
 		Tags: []string{EngineAll},
+		// LIKE search for pg_bigm does not distinguish between exact matches and partial matches in this test case.
+		Skip: true,
 	},
 	{
 		Name: "Should support terms with dash",
@@ -157,11 +163,16 @@ var searchPostStoreTests = []searchTest{
 		Name: "Should search or exclude post using hashtags",
 		Fn:   testSearchOrExcludePostsWithHashtags,
 		Tags: []string{EngineAll},
+		// LIKE search queries taeget only the message column, not the hashtag column.
+		// This test expcted posts with hashtags only in the hashtag column to be found.
+		Skip: true,
 	},
 	{
 		Name: "Should support searching for hashtags surrounded by markdown",
 		Fn:   testSearchHashtagWithMarkdown,
 		Tags: []string{EngineAll},
+		// The processing assumes that hashtags are located within text nodes, not within Markdown.
+		Skip: true,
 	},
 	{
 		Name: "Should support searching for multiple hashtags",
@@ -274,6 +285,8 @@ var searchPostStoreTests = []searchTest{
 		Name: "Should not return links that are embedded in markdown",
 		Fn:   testShouldNotReturnLinksEmbeddedInMarkdown,
 		Tags: []string{EnginePostgres, EngineElasticSearch},
+		// LIKE search for pg_bigm does not exclude terms inside markdown links.
+		Skip: true,
 	},
 	{
 		Name: "Should search across teams",

--- a/server/channels/store/sqlstore/file_info_store.go
+++ b/server/channels/store/sqlstore/file_info_store.go
@@ -530,7 +530,233 @@ func (fs SqlFileInfoStore) PermanentDeleteByUser(rctx request.CTX, userId string
 	return rowsAffected, nil
 }
 
+/*
+This function wraps Search() to enable LIKE search using pg_bigm index.
+*/
+func (fs SqlFileInfoStore) likesearch(rctx request.CTX, paramsList []*model.SearchParams, userId, teamId string, page, perPage int) (*model.FileInfoList, error) {
+	if err := model.IsSearchParamsListValid(paramsList); err != nil {
+		return nil, err
+	}
+
+	limit := uint64(perPage)
+	if perPage <= 0 || 60 < perPage {
+		limit = 60
+	}
+
+	// Fetch channel IDs separately first, then user them directly in the main query
+	channelQuery := fs.getQueryBuilder().
+		Select("DISTINCT Channels.Id").
+		From("Channels").
+		LeftJoin("ChannelMembers ON Channels.Id = ChannelMembers.ChannelId")
+
+	if teamId != "" {
+		channelQuery = channelQuery.Where(sq.Or{sq.Eq{"Channels.TeamId": teamId}, sq.Eq{"Channels.TeamId": ""}})
+	}
+
+	// Use the first params for common channel filters
+	params := paramsList[0]
+
+	if !params.IncludeDeletedChannels {
+		channelQuery = channelQuery.Where(sq.Eq{"Channels.DeleteAt": 0})
+	}
+	if !params.SearchWithoutUserId {
+		channelQuery = channelQuery.Where(sq.Eq{"ChannelMembers.UserId": userId})
+	}
+	if len(params.InChannels) != 0 {
+		channelQuery = channelQuery.Where(sq.Eq{"Channels.Id": params.InChannels})
+	}
+	if len(params.ExcludedChannels) != 0 {
+		channelQuery = channelQuery.Where(sq.NotEq{"Channels.Id": params.ExcludedChannels})
+	}
+
+	channelQueryStr, channelQueryArgs, err := channelQuery.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build channel query")
+	}
+
+	var channelIds []string
+	if err = fs.GetSearchReplicaX().Select(&channelIds, channelQueryStr, channelQueryArgs...); err != nil {
+		return nil, errors.Wrap(err, "failed to fetch channel IDs")
+	}
+
+	if len(channelIds) == 0 {
+		list := model.NewFileInfoList()
+		list.MakeNonNil()
+		return list, nil
+	}
+
+	// Build main query using the fetched channel IDs
+	query := fs.getQueryBuilder().
+		Select(fs.queryFields...).
+		From("FileInfo").
+		Where(sq.Eq{"FileInfo.DeleteAt": 0}).
+		Where(sq.Or{
+			sq.Eq{"FileInfo.CreatorId": model.BookmarkFileOwner},
+			sq.NotEq{"FileInfo.PostId": ""},
+		}).
+		Where(sq.Eq{"FileInfo.ChannelId": channelIds}).
+		OrderBy("FileInfo.CreateAt DESC").
+		Limit(limit)
+
+	if page > 0 {
+		query = query.Offset(uint64(page) * limit)
+	}
+
+	for _, params := range paramsList {
+		params.Terms = removeNonAlphaNumericUnquotedTerms(params.Terms, " ")
+
+		if len(params.Extensions) != 0 {
+			query = query.Where(sq.Eq{"FileInfo.Extension": params.Extensions})
+		}
+
+		if len(params.ExcludedExtensions) != 0 {
+			query = query.Where(sq.NotEq{"FileInfo.Extension": params.ExcludedExtensions})
+		}
+
+		if len(params.FromUsers) != 0 {
+			query = query.Where(sq.Eq{"FileInfo.CreatorId": params.FromUsers})
+		}
+
+		if len(params.ExcludedUsers) != 0 {
+			query = query.Where(sq.NotEq{"FileInfo.CreatorId": params.ExcludedUsers})
+		}
+
+		// handle after: before: on: filters
+		if params.OnDate != "" {
+			onDateStart, onDateEnd := params.GetOnDateMillis()
+			query = query.Where(sq.Expr("FileInfo.CreateAt BETWEEN ? AND ?", strconv.FormatInt(onDateStart, 10), strconv.FormatInt(onDateEnd, 10)))
+		} else {
+			if params.ExcludedDate != "" {
+				excludedDateStart, excludedDateEnd := params.GetExcludedDateMillis()
+				query = query.Where(sq.Expr("FileInfo.CreateAt NOT BETWEEN ? AND ?", strconv.FormatInt(excludedDateStart, 10), strconv.FormatInt(excludedDateEnd, 10)))
+			}
+
+			if params.AfterDate != "" {
+				afterDate := params.GetAfterDateMillis()
+				query = query.Where(sq.GtOrEq{"FileInfo.CreateAt": strconv.FormatInt(afterDate, 10)})
+			}
+
+			if params.BeforeDate != "" {
+				beforeDate := params.GetBeforeDateMillis()
+				query = query.Where(sq.LtOrEq{"FileInfo.CreateAt": strconv.FormatInt(beforeDate, 10)})
+			}
+
+			if params.ExcludedAfterDate != "" {
+				afterDate := params.GetExcludedAfterDateMillis()
+				query = query.Where(sq.Lt{"FileInfo.CreateAt": strconv.FormatInt(afterDate, 10)})
+			}
+
+			if params.ExcludedBeforeDate != "" {
+				beforeDate := params.GetExcludedBeforeDateMillis()
+				query = query.Where(sq.Gt{"FileInfo.CreateAt": strconv.FormatInt(beforeDate, 10)})
+			}
+		}
+
+		terms := params.Terms
+		excludedTerms := params.ExcludedTerms
+
+		for _, c := range fs.specialSearchChars() {
+			terms = strings.Replace(terms, c, " ", -1)
+			excludedTerms = strings.Replace(excludedTerms, c, " ", -1)
+		}
+
+		if terms == "" && excludedTerms == "" {
+			// we've already confirmed that we have a channel or user to search for
+		} else if fs.DriverName() == model.DatabaseDriverPostgres {
+			// Query generation customized for Japanese by bypassing the original implementation
+			// build LIKE search query using pg_bigm index
+
+			// Escape wildcards of LIKE searches used within strings with a backslash("\").
+			terms = sanitizeSearchTerm(terms, "\\")
+			excludedTerms = sanitizeSearchTerm(excludedTerms, "\\")
+
+			phrases := quotedStringsRegex.FindAllString(terms, -1)
+			terms = quotedStringsRegex.ReplaceAllLiteralString(terms, " ")
+			excludedPhrases := quotedStringsRegex.FindAllString(excludedTerms, -1)
+			excludedTerms = quotedStringsRegex.ReplaceAllLiteralString(excludedTerms, " ")
+
+			var likeConditions sq.And
+			var termQuery []sq.Sqlizer
+
+			// Make args lowercase for case-insensitive search.
+			phrases, excludedPhrases, terms, excludedTerms = toLowerSearchTerms(phrases, excludedPhrases, terms, excludedTerms)
+
+			termWords := strings.Fields(terms)
+			for _, term := range termWords {
+				termQuery = append(termQuery, sq.Or{
+					sq.Expr("LOWER(FileInfo.Name) LIKE ? ESCAPE '\\'", addWildcardToTerm(term, false)),
+					sq.Expr("LOWER(FileInfo.Content) LIKE ? ESCAPE '\\'", addWildcardToTerm(term, false)),
+				})
+			}
+			for _, phrase := range phrases {
+				phrase = strings.Trim(phrase, `"`)
+				if phrase == "" {
+					continue
+				}
+				termQuery = append(termQuery, sq.Or{
+					sq.Expr("LOWER(FileInfo.Name) LIKE ? ESCAPE '\\'", addWildcardToTerm(phrase, true)),
+					sq.Expr("LOWER(FileInfo.Content) LIKE ? ESCAPE '\\'", addWildcardToTerm(phrase, true)),
+				})
+			}
+
+			if (len(termQuery)) > 0 {
+				if params.OrTerms {
+					likeConditions = append(likeConditions, sq.Or(termQuery))
+				} else {
+					likeConditions = append(likeConditions, sq.And(termQuery))
+				}
+			}
+
+			excludedTermWord := strings.Fields(excludedTerms)
+			for _, term := range excludedTermWord {
+				likeConditions = append(likeConditions, sq.Expr("NOT (?)", sq.Or{
+					sq.Expr("LOWER(FileInfo.Name) LIKE ? ESCAPE '\\'", addWildcardToTerm(term, false)),
+					sq.Expr("LOWER(FileInfo.Content) LIKE ? ESCAPE '\\'", addWildcardToTerm(term, false)),
+				}))
+			}
+			for _, phrase := range excludedPhrases {
+				phrase = strings.Trim(phrase, `"`)
+				if phrase == "" {
+					continue
+				}
+				likeConditions = append(likeConditions, sq.Expr("NOT (?)", sq.Or{
+					sq.Expr("LOWER(FileInfo.Name) LIKE ? ESCAPE '\\'", addWildcardToTerm(phrase, true)),
+					sq.Expr("LOWER(FileInfo.Content) LIKE ? ESCAPE '\\'", addWildcardToTerm(phrase, true)),
+				}))
+			}
+
+			query = query.Where(likeConditions)
+		}
+	}
+
+	queryString, args, err := query.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "file_info_tosql")
+	}
+
+	list := model.NewFileInfoList()
+
+	items := []fileInfoWithChannelID{}
+	err = fs.GetSearchReplicaX().Select(&items, queryString, args...)
+	if err != nil {
+		rctx.Logger().Warn("Query error searching files.", mlog.String("error", trimInput(err.Error())))
+		// Don't return the error to the caller as it is of no use to the user. Instead return an empty set of search results.
+	} else {
+		for _, item := range items {
+			info := item.ToModel()
+			list.AddFileInfo(info)
+			list.AddOrder(info.Id)
+		}
+	}
+	list.MakeNonNil()
+	return list, nil
+}
+
 func (fs SqlFileInfoStore) Search(rctx request.CTX, paramsList []*model.SearchParams, userId, teamId string, page, perPage int) (*model.FileInfoList, error) {
+	if true {
+		return fs.likesearch(rctx, paramsList, userId, teamId, page, perPage)
+	}
+
 	// Since we don't support paging for DB search, we just return nothing for later pages
 	if page > 0 {
 		return model.NewFileInfoList(), nil

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -2796,8 +2796,32 @@ func (s *SqlPostStore) GetDirectPostParentsForExportAfter(limit int, afterId str
 	return result, nil
 }
 
+func (s *SqlPostStore) likeSearchPostsForUser(rctx request.CTX, paramsList []*model.SearchParams, userId, teamId string, page, perPage int) (*model.PostSearchResults, error) {
+	if err := model.IsSearchParamsListValid(paramsList); err != nil {
+		return nil, err
+	}
+
+	for _, params := range paramsList {
+		// remove any unquoted term that contains only non-alphanumeric chars
+		// ex: abcd "**" && abc     >>     abcd "**" abc
+		params.Terms = removeNonAlphaNumericUnquotedTerms(params.Terms, " ")
+	}
+
+	postList, err := s.likesearch(teamId, userId, paramsList, false, false, page, perPage)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return model.MakePostSearchResults(postList, nil), nil
+}
+
 //nolint:unparam
 func (s *SqlPostStore) SearchPostsForUser(rctx request.CTX, paramsList []*model.SearchParams, userId, teamId string, page, perPage int) (*model.PostSearchResults, error) {
+	if true {
+		return s.likeSearchPostsForUser(rctx, paramsList, userId, teamId, page, perPage)
+	}
+
 	// Since we don't support paging for DB search, we just return nothing for later pages
 	if page > 0 {
 		return model.MakePostSearchResults(model.NewPostList(), nil), nil

--- a/server/channels/store/sqlstore/post_store_like_search.go
+++ b/server/channels/store/sqlstore/post_store_like_search.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package sqlstore
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	sq "github.com/mattermost/squirrel"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+func addWildcardToTerm(term string, alwaysMiddleMatch bool) string {
+	// Accept prefix search when wildcard are in the appropriate position, otherwise treat as middle match.
+	// Suffix is only considered when the alwaysMiddleMatch is false.
+	if !strings.HasSuffix(term, "*") || alwaysMiddleMatch {
+		term = "%" + term + "%"
+	} else {
+		term = strings.TrimSuffix(term, "*") + "%"
+	}
+	return term
+}
+
+func toLowerSearchTerms(phrases, excludedPhrases []string, terms, excludedTerms string) ([]string, []string, string, string) {
+	for i, p := range phrases {
+		phrases[i] = strings.ToLower(p)
+	}
+	terms = strings.ToLower(terms)
+	excludedTerms = strings.ToLower(excludedTerms)
+	for i, p := range excludedPhrases {
+		excludedPhrases[i] = strings.ToLower(p)
+	}
+
+	return phrases, excludedPhrases, terms, excludedTerms
+}
+
+func toLowerSearchTypeForPosts(searchType string) string {
+	searchType = fmt.Sprintf("LOWER(%s)", searchType)
+
+	return searchType
+}
+
+func toLowerHashtagTermsForPosts(hashtagTerms string) string {
+	hashtagTerms = strings.ToLower(hashtagTerms)
+
+	return hashtagTerms
+}
+
+func buildPhrasesQuery(phrases []string, searchType string, searchClauses []string, searchArgs []any) ([]string, []any) {
+	for _, phrase := range phrases {
+		cleanPhrase := strings.Trim(phrase, `"`)
+		if cleanPhrase == "" {
+			continue
+		}
+		searchClauses = append(searchClauses, fmt.Sprintf("%s LIKE ? ESCAPE '\\'", searchType))
+		searchArgs = append(searchArgs, addWildcardToTerm(cleanPhrase, true))
+	}
+	return searchClauses, searchArgs
+}
+
+func buildTermsQuery(terms []string, searchType string, searchClauses []string, searchArgs []any) ([]string, []any) {
+	for _, term := range terms {
+		// Hashtags and mentions are searched with or without the prefix (# or @).
+		if strings.HasPrefix(term, "#") || strings.HasPrefix(term, "@") {
+			searchClauses = append(searchClauses, fmt.Sprintf("(%[1]s LIKE ? ESCAPE '\\' OR %[1]s LIKE ? ESCAPE '\\')", searchType))
+			searchArgs = append(searchArgs, addWildcardToTerm(term, true), addWildcardToTerm(term[1:], true))
+		} else {
+			searchClauses = append(searchClauses, fmt.Sprintf("%s LIKE ? ESCAPE '\\'", searchType))
+			searchArgs = append(searchArgs, addWildcardToTerm(term, false))
+		}
+	}
+	return searchClauses, searchArgs
+}
+
+func buildExcludedTermsQuery(excludedWords []string, searchType string, excludedClauses []string, excludedArgs []any) ([]string, []any) {
+	for _, word := range excludedWords {
+		cleanWord := strings.TrimPrefix(word, "-")
+		if cleanWord == "" {
+			continue
+		}
+		if strings.HasPrefix(cleanWord, "#") || strings.HasPrefix(cleanWord, "@") {
+			excludedClauses = append(excludedClauses, fmt.Sprintf("(%[1]s NOT LIKE ? ESCAPE '\\' AND %[1]s NOT LIKE ? ESCAPE '\\')", searchType))
+			excludedArgs = append(excludedArgs, addWildcardToTerm(cleanWord, true), addWildcardToTerm(cleanWord[1:], true))
+		} else {
+			excludedClauses = append(excludedClauses, fmt.Sprintf("%s NOT LIKE ? ESCAPE '\\'", searchType))
+			excludedArgs = append(excludedArgs, addWildcardToTerm(cleanWord, false))
+		}
+	}
+	return excludedClauses, excludedArgs
+}
+
+func buildExcludedPhrasesQuery(excludedPhrases []string, searchType string, excludedClauses []string, excludedArgs []any) ([]string, []any) {
+	for _, phrase := range excludedPhrases {
+		cleanPhrase := strings.Trim(phrase, `"`)
+		if cleanPhrase == "" {
+			continue
+		}
+		excludedClauses = append(excludedClauses, fmt.Sprintf("%s NOT LIKE ? ESCAPE '\\'", searchType))
+		excludedArgs = append(excludedArgs, addWildcardToTerm(cleanPhrase, true))
+	}
+	return excludedClauses, excludedArgs
+}
+
+func buildHashtagQuery(hashtags []string, searchType string, searchClauses []string, searchArgs []any) ([]string, []any) {
+	for _, hashtag := range hashtags {
+		if strings.HasPrefix(hashtag, "#") {
+			searchClauses = append(searchClauses, fmt.Sprintf("%s LIKE ? ESCAPE '\\'", searchType))
+			searchArgs = append(searchArgs, addWildcardToTerm(hashtag, true))
+		}
+	}
+	return searchClauses, searchArgs
+}
+
+/*
+The query built in this func assumes the existence of a functional index of LOWER() using pg_bigm.
+*/
+func (s *SqlPostStore) generateLikeSearchQueryForPosts(baseQuery sq.SelectBuilder, params *model.SearchParams, phrases, excludedPhrases []string, hashtagTerms, terms, excludedTerms string) sq.SelectBuilder {
+	var searchClauses []string
+	var searchArgs []any
+
+	searchType := "Message"
+
+	// Make args lowercase for case-insensitive search.
+	phrases, excludedPhrases, terms, excludedTerms = toLowerSearchTerms(phrases, excludedPhrases, terms, excludedTerms)
+	hashtagTerms = toLowerHashtagTermsForPosts(hashtagTerms)
+	searchType = toLowerSearchTypeForPosts(searchType)
+
+	// Search hashtags as normal terms, against `Message` column.
+	hashtags := strings.Fields((hashtagTerms))
+	searchClauses, searchArgs = buildHashtagQuery(hashtags, searchType, searchClauses, searchArgs)
+
+	// Phrase: strings enclosed in “” without splitting them.
+	searchClauses, searchArgs = buildPhrasesQuery(phrases, searchType, searchClauses, searchArgs)
+
+	termWords := strings.Fields(terms)
+	searchClauses, searchArgs = buildTermsQuery(termWords, searchType, searchClauses, searchArgs)
+
+	if len(searchClauses) > 0 {
+		logicalOperator := " AND "
+		if params.OrTerms {
+			logicalOperator = " OR "
+		}
+		baseQuery = baseQuery.Where("("+strings.Join(searchClauses, logicalOperator)+")", searchArgs...)
+	}
+
+	excludedWords := strings.Fields(excludedTerms)
+	if len(excludedWords) > 0 || len(excludedPhrases) > 0 {
+		var excludedClauses []string
+		var excludedArgs []any
+
+		excludedClauses, excludedArgs = buildExcludedTermsQuery(excludedWords, searchType, excludedClauses, excludedArgs)
+		excludedClauses, excludedArgs = buildExcludedPhrasesQuery(excludedPhrases, searchType, excludedClauses, excludedArgs)
+
+		if len(excludedClauses) > 0 {
+			baseQuery = baseQuery.Where(strings.Join(excludedClauses, " AND "), excludedArgs...)
+		}
+	}
+	return baseQuery
+}
+
+/**
+ * This function is an alternative to `search()` for replacing queries with like searches.
+ * Additionally, to support pagination, it has been modified to accepts params as a list and adds page and perpage arguments.
+ */
+func (s *SqlPostStore) likesearch(teamId string, userId string, paramsList []*model.SearchParams, channelsByName bool, userByUsername bool, page, perPage int) (*model.PostList, error) {
+	list := model.NewPostList()
+
+	// check if all params are empty
+	allEmpty := true
+	for _, params := range paramsList {
+		if !(params.Terms == "" && params.ExcludedTerms == "" &&
+			len(params.InChannels) == 0 && len(params.ExcludedChannels) == 0 &&
+			len(params.FromUsers) == 0 && len(params.ExcludedUsers) == 0 &&
+			params.OnDate == "" && params.AfterDate == "" && params.BeforeDate == "") {
+			allEmpty = false
+			break
+		}
+	}
+	if allEmpty {
+		return list, nil
+	}
+
+	limit := uint64(perPage)
+	if perPage <= 0 || 60 < perPage {
+		limit = 60
+	}
+
+	baseQuery := s.getQueryBuilder().Select(
+		"*",
+		"(SELECT COUNT(*) FROM Posts WHERE Posts.RootId = (CASE WHEN q2.RootId = '' THEN q2.Id ELSE q2.RootId END) AND Posts.DeleteAt = 0) as ReplyCount",
+	).From("Posts q2").
+		Where("q2.DeleteAt = 0").
+		Where(fmt.Sprintf("q2.Type NOT LIKE '%s%%'", model.PostSystemMessagePrefix)).
+		OrderByClause("q2.CreateAt DESC").
+		Limit(limit)
+
+	if page > 0 {
+		baseQuery = baseQuery.Offset(uint64(page) * limit)
+	}
+
+	// Use the first params for common filters (channel, date, user filters are same across all params)
+	params := paramsList[0]
+
+	var err error
+	baseQuery, err = s.buildSearchPostFilterClause(teamId, params.FromUsers, params.ExcludedUsers, userByUsername, baseQuery)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build search post filter clause")
+	}
+	baseQuery = s.buildCreateDateFilterClause(params, baseQuery)
+
+	var allTerms []string
+	var allExcludedTerms []string
+	var allHashtagTerms []string
+
+	// Combine the Terms & excludedTerms stored within each params into a single entity
+	for _, params := range paramsList {
+		if params.IsHashtag {
+			for term := range strings.SplitSeq(params.Terms, " ") {
+				if term != "" {
+					allHashtagTerms = append(allHashtagTerms, term)
+				}
+			}
+		} else if params.Terms != "" {
+			allTerms = append(allTerms, params.Terms)
+		}
+
+		if params.ExcludedTerms != "" {
+			allExcludedTerms = append(allExcludedTerms, params.ExcludedTerms)
+		}
+	}
+
+	terms := strings.Join(allTerms, " ")
+	excludedTerms := strings.Join(allExcludedTerms, " ")
+	hashtagTerms := strings.Join(allHashtagTerms, " ")
+
+	if terms == "" && excludedTerms == "" && hashtagTerms == "" {
+		// we've already confirmed that we have a channel or user to search for
+	} else {
+		// Query generation customized for Japanese by bypassing the original implementation
+		// build LIKE search query using pg_bigm index
+
+		// Escape wildcards of LIKE searches used within strings with a backslash("\").
+		terms = sanitizeSearchTerm(terms, "\\")
+		excludedTerms = sanitizeSearchTerm(excludedTerms, "\\")
+		hashtagTerms = sanitizeSearchTerm(hashtagTerms, "\\")
+
+		phrases := quotedStringsRegex.FindAllString(terms, -1)
+		terms = quotedStringsRegex.ReplaceAllLiteralString(terms, " ")
+		excludedPhrases := quotedStringsRegex.FindAllString(excludedTerms, -1)
+		excludedTerms = quotedStringsRegex.ReplaceAllLiteralString(excludedTerms, " ")
+
+		baseQuery = s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+	}
+
+	inQuery := s.getSubQueryBuilder().Select("Channels.Id").
+		From("Channels, ChannelMembers").
+		Where("Channels.Id = ChannelMembers.ChannelId")
+
+	if !params.IncludeDeletedChannels {
+		inQuery = inQuery.Where("Channels.DeleteAt = 0")
+	}
+
+	if !params.SearchWithoutUserId {
+		inQuery = inQuery.Where("ChannelMembers.UserId = ?", userId)
+	}
+
+	inQuery = s.buildSearchTeamFilterClause(teamId, inQuery)
+	inQuery = s.buildSearchChannelFilterClause(params.InChannels, false, channelsByName, inQuery)
+	inQuery = s.buildSearchChannelFilterClause(params.ExcludedChannels, true, channelsByName, inQuery)
+
+	inQueryClause, inQueryClauseArgs, err := inQuery.ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	var channelIds []string
+	if err = s.GetSearchReplicaX().Select(&channelIds, inQueryClause, inQueryClauseArgs...); err != nil {
+		mlog.Warn("Failed to fetch channel IDs for search", mlog.String("error", trimInput(err.Error())))
+	}
+
+	if len(channelIds) == 0 {
+		list.MakeNonNil()
+		return list, nil
+	}
+
+	baseQuery = baseQuery.Where(sq.Eq{"ChannelId": channelIds})
+
+	searchQuery, searchQueryArgs, err := baseQuery.ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	var posts []*model.Post
+
+	if err := s.GetSearchReplicaX().Select(&posts, searchQuery, searchQueryArgs...); err != nil {
+		mlog.Warn("Query error searching posts.", mlog.String("error", trimInput(err.Error())))
+		// Don't return the error to the caller as it is of no use to the user. Instead return an empty set of search results.
+	} else {
+		for _, p := range posts {
+			if p.DeleteAt == 0 {
+				list.AddPost(p)
+				list.AddOrder(p.Id)
+			}
+		}
+	}
+	list.MakeNonNil()
+	return list, nil
+}

--- a/server/channels/store/sqlstore/post_store_like_search_test.go
+++ b/server/channels/store/sqlstore/post_store_like_search_test.go
@@ -1,0 +1,538 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package sqlstore
+
+import (
+	"strings"
+	"testing"
+
+	sq "github.com/mattermost/squirrel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+func TestGenerateLikeSearchQuery(t *testing.T) {
+	if enableFullyParallelTests {
+		t.Parallel()
+	}
+
+	s := &SqlPostStore{}
+
+	t.Run("basic term search", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "hello"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 1, len(args))
+		assert.Equal(t, "%hello%", args[0])
+	})
+
+	t.Run("multiple terms with AND operator", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "hello world"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, " AND ")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%hello%", args[0])
+		assert.Equal(t, "%world%", args[1])
+	})
+
+	t.Run("multiple terms with OR operator", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: true}
+		phrases := []string{}
+		terms := "hello world"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, " OR ")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%hello%", args[0])
+		assert.Equal(t, "%world%", args[1])
+	})
+
+	t.Run("phrase search with quotes", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{`"hello world"`}
+		terms := ""
+		excludedPhrases := []string{}
+		excludedTerms := ""
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 1, len(args))
+		assert.Equal(t, "%hello world%", args[0])
+	})
+
+	t.Run("multiple phrases", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{`"hello world"`, `"test phrase"`}
+		terms := ""
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, " AND ")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%hello world%", args[0])
+		assert.Equal(t, "%test phrase%", args[1])
+	})
+
+	t.Run("hashtag search with prefix", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "#hashtag"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "(LOWER(Message) LIKE ? ESCAPE '\\' OR LOWER(Message) LIKE ? ESCAPE '\\')")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%#hashtag%", args[0])
+		assert.Equal(t, "%hashtag%", args[1])
+	})
+
+	t.Run("mention search with @ prefix", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "@username"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "(LOWER(Message) LIKE ? ESCAPE '\\' OR LOWER(Message) LIKE ? ESCAPE '\\')")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%@username%", args[0])
+		assert.Equal(t, "%username%", args[1])
+	})
+
+	t.Run("multiple hashtags with OR", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: true}
+		phrases := []string{}
+		terms := "#tag1 #tag2"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, " OR ")
+		assert.Equal(t, 4, len(args))
+		assert.Equal(t, "%#tag1%", args[0])
+		assert.Equal(t, "%tag1%", args[1])
+		assert.Equal(t, "%#tag2%", args[2])
+		assert.Equal(t, "%tag2%", args[3])
+	})
+
+	t.Run("wildcard suffix handling", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "test*"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 1, len(args))
+		assert.Equal(t, "test%", args[0])
+	})
+
+	t.Run("excluded terms", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "hello"
+		excludedTerms := "world"
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, "LOWER(Message) NOT LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%hello%", args[0])
+		assert.Equal(t, "%world%", args[1])
+	})
+
+	t.Run("multiple excluded terms", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "hello"
+		excludedTerms := "world test"
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, "LOWER(Message) NOT LIKE ? ESCAPE '\\'")
+		// Count the number of AND operators for excluded terms
+		excludedAndCount := strings.Count(sql, "NOT LIKE")
+		assert.Equal(t, 2, excludedAndCount)
+		assert.Equal(t, 3, len(args))
+		assert.Equal(t, "%hello%", args[0])
+		assert.Equal(t, "%world%", args[1])
+		assert.Equal(t, "%test%", args[2])
+	})
+
+	t.Run("excluded hashtag with prefix", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "hello"
+		excludedTerms := "#hashtag"
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, "(LOWER(Message) NOT LIKE ? ESCAPE '\\' AND LOWER(Message) NOT LIKE ? ESCAPE '\\')")
+		assert.Equal(t, 3, len(args))
+		assert.Equal(t, "%hello%", args[0])
+		assert.Equal(t, "%#hashtag%", args[1])
+		assert.Equal(t, "%hashtag%", args[2])
+	})
+
+	t.Run("excluded mention with @ prefix", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "hello"
+		excludedTerms := "@username"
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, "(LOWER(Message) NOT LIKE ? ESCAPE '\\' AND LOWER(Message) NOT LIKE ? ESCAPE '\\')")
+		assert.Equal(t, 3, len(args))
+		assert.Equal(t, "%hello%", args[0])
+		assert.Equal(t, "%@username%", args[1])
+		assert.Equal(t, "%username%", args[2])
+	})
+
+	t.Run("excluded term with wildcard", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "hello"
+		excludedTerms := "test*"
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, "LOWER(Message) NOT LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%hello%", args[0])
+		assert.Equal(t, "test%", args[1])
+	})
+
+	t.Run("excluded phrases", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "appear"
+		excludedTerms := ""
+		excludedPhrases := []string{"will not"}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, "LOWER(Message) NOT LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%appear%", args[0])
+		assert.Equal(t, "%will not%", args[1])
+	})
+
+	t.Run("case insensitive search", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "HELLO"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 1, len(args))
+		// Should be converted to lowercase
+		assert.Equal(t, "%hello%", args[0])
+	})
+
+	t.Run("case insensitive phrase search", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{`"HelLO WorLd"`}
+		terms := ""
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 1, len(args))
+		// Should be converted to lowercase
+		assert.Equal(t, "%hello world%", args[0])
+	})
+
+	t.Run("case insensitive excluded terms", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "hello"
+		excludedTerms := "WORLD"
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) NOT LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%hello%", args[0])
+		// Should be converted to lowercase
+		assert.Equal(t, "%world%", args[1])
+	})
+
+	t.Run("combined phrases and terms", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{`"hello world"`}
+		terms := "test"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, " AND ")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%hello world%", args[0])
+		assert.Equal(t, "%test%", args[1])
+	})
+
+	t.Run("empty phrases should be ignored", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{`""`, `"valid phrase"`}
+		terms := ""
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		// Only one phrase should be included
+		assert.Equal(t, 1, len(args))
+		assert.Equal(t, "%valid phrase%", args[0])
+	})
+
+	t.Run("empty excluded terms should be ignored", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "hello"
+		excludedTerms := `"" -`
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, "LOWER(Message) NOT LIKE ? ESCAPE '\\'")
+		// The term "hello" and the literal "" (two quotes) as excluded term, minus the standalone "-" which is empty after trimming
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%hello%", args[0])
+		assert.Equal(t, `%""%`, args[1])
+	})
+
+	t.Run("no search terms results in no WHERE clause", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := ""
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, _, err := result.ToSql()
+
+		require.NoError(t, err)
+		// Should not add any search conditions
+		assert.NotContains(t, sql, "LIKE")
+	})
+
+	t.Run("only excluded terms without search terms", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := ""
+		excludedTerms := "world"
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) NOT LIKE ? ESCAPE '\\'")
+		assert.Equal(t, 1, len(args))
+		assert.Equal(t, "%world%", args[0])
+	})
+
+	t.Run("mixed hashtags, mentions and regular terms", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "#hashtag @username regular"
+		excludedTerms := ""
+		excludedPhrases := []string{}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "(LOWER(Message) LIKE ? ESCAPE '\\' OR LOWER(Message) LIKE ? ESCAPE '\\')")
+		assert.Contains(t, sql, " AND ")
+		assert.Equal(t, 5, len(args))
+		assert.Equal(t, "%#hashtag%", args[0])
+		assert.Equal(t, "%hashtag%", args[1])
+		assert.Equal(t, "%@username%", args[2])
+		assert.Equal(t, "%username%", args[3])
+		assert.Equal(t, "%regular%", args[4])
+	})
+
+	t.Run("mixed hashtags, mentions and regular terms in japanese", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{}
+		terms := "田中"
+		excludedTerms := ""
+		excludedPhrases := []string{"太郎 社長"}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "(LOWER(Message) LIKE ? ESCAPE '\\') AND LOWER(Message) NOT LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, " AND ")
+		assert.Equal(t, 2, len(args))
+		assert.Equal(t, "%田中%", args[0])
+		assert.Equal(t, "%太郎 社長%", args[1])
+	})
+
+	t.Run("complex query with all features", func(t *testing.T) {
+		baseQuery := sq.Select("*").From("Posts")
+		params := &model.SearchParams{OrTerms: false}
+		phrases := []string{`"exact phrase"`}
+		terms := "#hashtag @mention word test*"
+		excludedTerms := "excluded #excludedtag"
+		excludedPhrases := []string{"excluded phrase", "another excluded"}
+		hashtagTerms := ""
+
+		result := s.generateLikeSearchQueryForPosts(baseQuery, params, phrases, excludedPhrases, hashtagTerms, terms, excludedTerms)
+		sql, args, err := result.ToSql()
+
+		require.NoError(t, err)
+		assert.Contains(t, sql, "LOWER(Message) LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, "LOWER(Message) NOT LIKE ? ESCAPE '\\'")
+		assert.Contains(t, sql, " AND ")
+		// phrase + hashtag (2) + mention (2) + word + test% + excluded + excludedtag (2)
+		assert.Equal(t, 12, len(args))
+	})
+}


### PR DESCRIPTION
Revert "Revert "Modified the full-text search implementation to be compatible with pg_bigm"".

- #80 
#83 
を独立してデプロイする方針になりました。


#83 が#80 に対してMerged判定になっているので、#80 に対する#83 のRevertをRevertして新しいブランチで新しいPRを作成しました。

#83 と内容は同一ですので、説明はそちらを参照いただけますと幸いです。