### PR TITLE
add "unread: true" to reduce DB access

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
@@ -93,7 +93,7 @@ export function getThreadsForCurrentTeam({before = '', after = '', unread = fals
 
 export function getThreadCounts(userId: string, teamId: string): ActionFuncAsync {
     return async (dispatch) => {
-        const response = await dispatch(fetchThreads(userId, teamId, {totalsOnly: true, threadsOnly: false}));
+        const response = await dispatch(fetchThreads(userId, teamId, {unread: true, totalsOnly: true, threadsOnly: false}));
 
         if (response.error) {
             return response;


### PR DESCRIPTION
## 背景
- https://github.com/stmninc/tunag-chat/issues/632

- 上のIssueでも認識しているが、
Threads関連のクエリがDB負荷の高いクエリの上位５位をしめている。これらの負荷を軽減させたい。
このPRではIssueにあるクエリCのリクエスト数削減を試みる。

## 実装の意図
#### Back
- クエリC発行元にこのようにコメントが記載されており、GetTotalUnreadThreadsの数値で代替しても良いようだった。
https://github.com/stmninc/mattermost/blob/3b82a3309a4d4454e69c4a7a46c6458ba0f758ec/server/channels/app/user.go#L2683-L2696
https://github.com/stmninc/mattermost/blob/3b82a3309a4d4454e69c4a7a46c6458ba0f758ec/server/channels/app/user.go#L2737-L2739

#### Front
- ウェブアプリケーションのマウント時に依存配列が初期化されることで、スレッドの状態を取得するAPIが自動的に叩かれている。
https://github.com/stmninc/mattermost/blob/3b82a3309a4d4454e69c4a7a46c6458ba0f758ec/webapp/channels/src/components/threading/global_threads/global_threads.tsx#L83-L85

- この処理において`options.Unread: true`に設定することで、（少なくともマウント時には）不要であると思われるDBアクセスをスキップさせる。

## 検証
- total_unread_mentionsはバッジの数値、total_unread_threadsの値は０以上で「スレッド」の文字をハイライトするのに使用している。
totalは現在のスレッド数を表すが、少なくともリロード時に発行される段階では数値を使用しない。
そこでこの不要なtotalでDBを呼び出さないために、フロント側でリロードされる際に、`options.unread = true`に設定した。
### 変更前
<img width="296" height="122" alt="Image" src="https://github.com/user-attachments/assets/0a25f783-c1d7-472f-b09d-8fdc064a1ef3" /> 

<img width="686" height="498" alt="Image" src="https://github.com/user-attachments/assets/2b1e8ba2-14a5-4ac6-9153-3fb777d377b9" />

### 変更後
- 表示上、特に支障はない。
<img width="274" height="114" alt="Image" src="https://github.com/user-attachments/assets/3151fc11-aa5a-4764-a378-747a048f4cd1" />

<img width="674" height="504" alt="Image" src="https://github.com/user-attachments/assets/bfc343fa-9dc2-4b2f-bd2a-377d7239027b" />



------
- ウェブアプリケーション再起動時のDBアクセス負荷軽減に寄与すると思われる。

- 具体的には、アプリケーション起動時に負荷３位にあるクエリがスキップされる。
<img width="1393" height="495" alt="image" src="https://github.com/user-attachments/assets/5ff6afdc-fcdd-4edb-bc83-a38bd27eeaf9" />
