### PR TITLE
unread:true to reduce DB access in syncThreads()

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/threads.ts
@@ -125,7 +125,7 @@ export function getThreadCounts(userId: string, teamId: string): ActionFuncAsync
 
 export function getCountsAndThreadsSince(userId: string, teamId: string, since?: number): ActionFuncAsync {
     return async (dispatch) => {
-        const response = await dispatch(fetchThreads(userId, teamId, {since, totalsOnly: false, threadsOnly: false, extended: true}));
+        const response = await dispatch(fetchThreads(userId, teamId, {since, unread: true, totalsOnly: false, threadsOnly: false, extended: true}));
 
         if (response.error) {
             return response;


### PR DESCRIPTION
## 背景
- https://github.com/stmninc/tunag-chat/issues/632

## 実装の意図
Issue632にあるWebsocketの再接続時に行われる、Threads情報取得のDB負荷を軽減する。
unread: trueにすることで、サーバー側で不必要な処理をスキップさせる。

- https://github.com/stmninc/mattermost/pull/128
実装意図の詳細はこちらに記載しています。
こちらはウェブアプリ再起動時に行われる、Threads情報取得に対してのPRです。


## 検証結果

Websocket再接続時に発行されるThreadsのAPIを確認した。
<img width="1464" height="300" alt="image" src="https://github.com/user-attachments/assets/3efa4f4d-dcce-4ec3-9160-fe791f841926" />


以下そのURL。
https://toreview.chat.tunag.jp/api/v4/users/csq9uw6txtd4xxfb5eorjpbj8r/teams/queuzsg7jir5tgdp496r7meuuw/threads?before=&after=&per_page=20&extended=true&deleted=false&unread=true&since=1764744198158&totalsOnly=false&threadsOnly=false

unread = trueで設定できている。