### PR TITLE
Disable to fetch getMyTeamUnread() to reduce unnecessary DB access

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.jsx
+++ b/webapp/channels/src/actions/websocket_actions.jsx
@@ -260,7 +260,7 @@ export function reconnect() {
         }
 
         const crtEnabled = isCollapsedThreadsEnabled(state);
-        dispatch(TeamActions.getMyTeamUnreads(crtEnabled));
+        dispatch(TeamActions.getMyTeamUnreads(false));
         if (crtEnabled) {
             const teams = getMyTeams(state);
             syncThreads(currentTeamId, currentUserId);


### PR DESCRIPTION
## 背景
- https://github.com/stmninc/tunag-chat/issues/632

Threadsの情報取得で発行されるクエリのDB負荷が高い。そのため無駄な処理を減らしたい。



## 実装の意図
- Websocketの再接続時に行われる、**他のTeamの**Threads情報取得におけるDBアクセスをスキップさせる。
ツナグチャットでは「他のTeam」には所属できないので、このDBアクセスは必要でない。
https://github.com/stmninc/mattermost/blob/3b82a3309a4d4454e69c4a7a46c6458ba0f758ec/webapp/channels/src/actions/websocket_actions.jsx#L262-L263

- フロントエンドで`include_collapsed_threads = false`にハードコードすることで、バックエンドでのDBアクセスを弾く。
https://github.com/stmninc/mattermost/blob/d1dd74fe3b547e6a977186183d78d79b137e97aa/server/channels/app/team.go#L1714-L1717

- 実際にスキップされるDBアクセスは以下。
ThreadCount, ThreadMentionCount, ThreadsUrgentMentionCountが使われていないことを確認済み。
https://github.com/stmninc/mattermost/blob/3b82a3309a4d4454e69c4a7a46c6458ba0f758ec/server/channels/app/team.go#L1710-L1724

## 検証結果

Websocket再接続時に発行されるThreadsのAPIを確認した。
<img width="1465" height="453" alt="image" src="https://github.com/user-attachments/assets/04cc8c5c-7d31-40bd-9dd0-ebd4ac7b6a3f" />



以下そのURL。
https://toreview.chat.tunag.jp/api/v4/users/me/teams/unread?include_collapsed_threads=false

include_collapsed_threads = false で設定できている。



----------
#### 関連するPR
- https://github.com/stmninc/mattermost/pull/128
こちらはウェブアプリ再起動時に行われる、Threads情報取得に対してのPRです。
- https://github.com/stmninc/mattermost/pull/130
こちらはWebsocket再起動時に行われる、**現在いるTeamの**Threads情報取得に対してのRPです。