### PR TITLE
Improve GetTotalUnreadMentions query performance

### DIFF
--- a/server/channels/store/sqlstore/thread_store.go
+++ b/server/channels/store/sqlstore/thread_store.go
@@ -214,7 +214,10 @@ func (s *SqlThreadStore) GetTotalUnreadMentions(userId, teamId string, opts mode
 	}
 
 	if !opts.Deleted {
-		query = query.Where(sq.Eq{"COALESCE(Threads.ThreadDeleteAt, 0)": 0})
+		query = query.Where(sq.Or{
+			sq.Eq{"Threads.ThreadDeleteAt": nil},
+			sq.Eq{"Threads.ThreadDeleteAt": 0},
+		})
 	}
 
 	err := s.GetReplica().GetBuilder(&totalUnreadMentions, query)


### PR DESCRIPTION
The query issued by ``GetTotalUnreadMentions()`` has poor performance. The use of COALESCE is degrading performance. By removing the use of COALESCE, the database optimizer can build a more efficient query plan.
- https://github.com/stmninc/tunag-chat/issues/637

Specifically, it improves in the following ways.
- Using a Hash Join instead of a Nested Loop.
- More efficient use of indexes on the ThreadMemberships table.
- It no longer executes parallel queries.

I've described the details below.
- https://github.com/stmninc/tunag-chat/issues/637#issuecomment-3609367092

I confirmed in the logs that a query executed the below.
```sql
SELECT COALESCE(SUM(ThreadMemberships.UnreadMentions),0) FROM ThreadMemberships LEFT JOIN Threads ON Threads.PostId = ThreadMemberships.PostId WHERE ThreadMemberships.Following = $1 AND ThreadMemberships.UserId = $2 AND (Threads.ThreadTeamId = $3 OR Threads.ThreadTeamId = $4) AND (Threads.ThreadDeleteAt IS NULL OR Threads.ThreadDeleteAt = $5)
```
