### PR TITLE
Improve GetTotalUnreadThreads() query pereformance 

### DIFF
--- a/server/channels/store/sqlstore/thread_store.go
+++ b/server/channels/store/sqlstore/thread_store.go
@@ -147,7 +147,10 @@ func (s *SqlThreadStore) getTotalThreadsQuery(userId, teamId string, opts model.
 	}
 
 	if !opts.Deleted {
-		query = query.Where(sq.Eq{"COALESCE(Threads.ThreadDeleteAt, 0)": 0})
+		query = query.Where(sq.Or{
+			sq.Eq{"Threads.ThreadDeleteAt": nil},
+			sq.Eq{"Threads.ThreadDeleteAt": 0},
+		})
 	}
 
 	return query


### PR DESCRIPTION
- This PR applies the fix to `GetTotalUnreadThreads()` same as #132  .

The use of COALESCE is degrading performance. By removing the use of COALESCE, the database optimizer can build a more efficient query plan.
This PR reduce the database load from `GetTotalThreadQuery()` in `(s *SqlThreadStore)GetTotalUnreadThreads`.
（recommended by:  https://github.com/stmninc/mattermost/pull/132#discussion_r2587040447 ）

## background
- This PR is the part of this issue.
https://github.com/stmninc/tunag-chat/issues/637#issuecomment-3609367092

## verification
- Applying functions to WHERE clauses often prevents the database from correctly using its internal statistic values.
- By removing the function `COALESCE` from the WHERE clause, the query plan is now generated based on the correct values.
- Compared to Before, the total estimated cost has increased, but the cost in Before was calculated based on an incorrect value (Threads Raw = 241).
In After, however, the correct value is estimated (Threads Raw = 81665).
As a result, `Hashjoin` which can handle large numbers, is now called instead of `Nested Loop`.


**Query**
```SQL
EXPLAIN SELECT
  COUNT(ThreadMemberships.PostId)
FROM
  ThreadMemberships
LEFT JOIN
  Threads ON Threads.PostId = ThreadMemberships.PostId
WHERE
  ThreadMemberships.UserId = '3cr5ori3d7ywunds8is6hu1wcy'
  AND ThreadMemberships.Following = true
  AND (Threads.ThreadTeamId = 'j4586eeb4py8pq6dqyj6gnmd4h' OR Threads.ThreadTeamId = '')
  AND (Threads.ThreadDeleteAt IS NULL OR Threads.ThreadDeleteAt = 0)
  AND ThreadMemberships.LastViewed < Threads.LastReplyAt;
```
**After**
```SQL
                                                                                    QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=9194.27..9194.28 rows=1 width=8)
   ->  Hash Join  (cost=4700.40..9192.57 rows=680 width=27)
         Hash Cond: ((threads.postid)::text = (threadmemberships.postid)::text)
         Join Filter: (threadmemberships.lastviewed < threads.lastreplyat)
         ->  Seq Scan on threads  (cost=0.00..4277.80 rows=81665 width=35)
               Filter: (((threaddeleteat IS NULL) OR (threaddeleteat = 0)) AND (((threadteamid)::text = 'j4586eeb4py8pq6dqyj6gnmd4h'::text) OR ((threadteamid)::text = ''::text)))
         ->  Hash  (cost=4672.25..4672.25 rows=2252 width=35)
               ->  Bitmap Heap Scan on threadmemberships  (cost=42.85..4672.25 rows=2252 width=35)
                     Recheck Cond: ((userid)::text = '3cr5ori3d7ywunds8is6hu1wcy'::text)
                     Filter: following
                     ->  Bitmap Index Scan on idx_thread_memberships_user_id  (cost=0.00..42.29 rows=2382 width=0)
                           Index Cond: ((userid)::text = '3cr5ori3d7ywunds8is6hu1wcy'::text)
(12 行)
```

**Before**
```SQL
                                                                                       QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=6602.67..6602.68 rows=1 width=8)
   ->  Gather  (cost=6602.55..6602.66 rows=1 width=8)
         Workers Planned: 1
         ->  Partial Aggregate  (cost=5602.55..5602.56 rows=1 width=8)
               ->  Nested Loop  (cost=0.42..5602.55 rows=2 width=27)
                     ->  Parallel Seq Scan on threads  (cost=0.00..3628.53 rows=241 width=35)
                           Filter: ((COALESCE(threaddeleteat, '0'::bigint) = 0) AND (((threadteamid)::text = 'j4586eeb4py8pq6dqyj6gnmd4h'::text) OR ((threadteamid)::text = ''::text)))
                     ->  Index Scan using threadmemberships_pkey on threadmemberships  (cost=0.42..8.18 rows=1 width=35)
                           Index Cond: (((postid)::text = (threads.postid)::text) AND ((userid)::text = '3cr5ori3d7ywunds8is6hu1wcy'::text))
                           Filter: (following AND (lastviewed < threads.lastreplyat))
(10 行)
```
