### PR TITLE
Improve GetTeamsUnreadForUser() query performance

### DIFF
--- a/server/channels/store/sqlstore/thread_store.go
+++ b/server/channels/store/sqlstore/thread_store.go
@@ -404,7 +404,10 @@ func (s *SqlThreadStore) GetTeamsUnreadForUser(userID string, teamIDs []string, 
 		sq.Eq{"ThreadMemberships.UserId": userID},
 		sq.Eq{"ThreadMemberships.Following": true},
 		sq.Eq{"Threads.ThreadTeamId": teamIDs},
-		sq.Eq{"COALESCE(Threads.ThreadDeleteAt, 0)": 0},
+		sq.Or{
+			sq.Eq{"Threads.ThreadDeleteAt": nil},
+			sq.Eq{"Threads.ThreadDeleteAt": 0},
+		},
 	}
 
 	var eg errgroup.Group


### PR DESCRIPTION
- This PR applies the fix to `GetTeamsUnreadForUser()` same as #132  .

The use of COALESCE is degrading performance. By removing the use of COALESCE, the database optimizer can build a more efficient query plan.
This PR reduce the database load from `(s *SqlThreadStore)GetTreamsUnreadForUser`.
（recommended by:  https://github.com/stmninc/mattermost/pull/132#discussion_r2587040447 ）

## background
- This PR is the part of this issue.
https://github.com/stmninc/tunag-chat/issues/637#issuecomment-3609367092

## verification
- It also verified in this PR. #133 
- Applying functions to WHERE clauses often prevents the database from correctly using its internal statistic values.
- By removing the function `COALESCE` from the WHERE clause, the query plan is now generated based on the correct values.
- Compared to Before, the total estimated cost has increased, but the cost in Before was calculated based on an incorrect value (Threads Raw = 241).
In After, however, the correct value is estimated (Threads Raw = 81665).
As a result, `Hashjoin` which can handle large numbers, is now called instead of `Nested Loop`.

**repliesQuery**
```SQL
EXPLAIN SELECT
  COUNT(Threads.PostId) AS Count,
  ThreadTeamId AS TeamId
FROM
  Threads
LEFT JOIN
  ThreadMemberships ON Threads.PostId = ThreadMemberships.PostId
WHERE
  ThreadMemberships.UserId = '3cr5ori3d7ywunds8is6hu1wcy'
  AND ThreadMemberships.Following = true
  AND Threads.ThreadTeamId IN ('j4586eeb4py8pq6dqyj6gnmd4h')
  AND (
    Threads.ThreadDeleteAt IS NULL
    OR Threads.ThreadDeleteAt = 0
  )
  AND Threads.LastReplyAt > ThreadMemberships.LastViewed
GROUP BY
  Threads.ThreadTeamId;
```

```SQL
                                                                 QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=4700.40..8968.25 rows=3 width=32)
   Group Key: threads.threadteamid
   ->  Hash Join  (cost=4700.40..8964.85 rows=673 width=51)
         Hash Cond: ((threads.postid)::text = (threadmemberships.postid)::text)
         Join Filter: (threads.lastreplyat > threadmemberships.lastviewed)
         ->  Seq Scan on threads  (cost=0.00..4052.55 rows=80727 width=59)
               Filter: (((threaddeleteat IS NULL) OR (threaddeleteat = 0)) AND ((threadteamid)::text = 'j4586eeb4py8pq6dqyj6gnmd4h'::text))
         ->  Hash  (cost=4672.25..4672.25 rows=2252 width=35)
               ->  Bitmap Heap Scan on threadmemberships  (cost=42.85..4672.25 rows=2252 width=35)
                     Recheck Cond: ((userid)::text = '3cr5ori3d7ywunds8is6hu1wcy'::text)
                     Filter: following
                     ->  Bitmap Index Scan on idx_thread_memberships_user_id  (cost=0.00..42.29 rows=2382 width=0)
                           Index Cond: ((userid)::text = '3cr5ori3d7ywunds8is6hu1wcy'::text)
(13 行)

```

**mentionsQuery**
```SQL
EXPLAIN SELECT
  COALESCE(SUM(ThreadMemberships.UnreadMentions), 0) AS Count,
  ThreadTeamId AS TeamId
FROM
  ThreadMemberships
LEFT JOIN
  Threads ON Threads.PostId = ThreadMemberships.PostId
WHERE
  ThreadMemberships.UserId = '3cr5ori3d7ywunds8is6hu1wcy'
  AND ThreadMemberships.Following = true
  AND Threads.ThreadTeamId IN ('j4586eeb4py8pq6dqyj6gnmd4h')
  AND (
    Threads.ThreadDeleteAt IS NULL
    OR Threads.ThreadDeleteAt = 0
  )
GROUP BY
  Threads.ThreadTeamId;
```


```SQL
                                                                 QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=4700.40..8974.99 rows=3 width=56)
   Group Key: threads.threadteamid
   ->  Hash Join  (cost=4700.40..8964.86 rows=2018 width=32)
         Hash Cond: ((threads.postid)::text = (threadmemberships.postid)::text)
         ->  Seq Scan on threads  (cost=0.00..4052.55 rows=80727 width=51)
               Filter: (((threaddeleteat IS NULL) OR (threaddeleteat = 0)) AND ((threadteamid)::text = 'j4586eeb4py8pq6dqyj6gnmd4h'::text))
         ->  Hash  (cost=4672.25..4672.25 rows=2252 width=35)
               ->  Bitmap Heap Scan on threadmemberships  (cost=42.85..4672.25 rows=2252 width=35)
                     Recheck Cond: ((userid)::text = '3cr5ori3d7ywunds8is6hu1wcy'::text)
                     Filter: following
                     ->  Bitmap Index Scan on idx_thread_memberships_user_id  (cost=0.00..42.29 rows=2382 width=0)
                           Index Cond: ((userid)::text = '3cr5ori3d7ywunds8is6hu1wcy'::text)
(12 行)
```

**urgentMentionsQuery**
```SQL
EXPLAIN SELECT
  COALESCE(SUM(ThreadMemberships.UnreadMentions), 0) AS Count,
  ThreadTeamId AS TeamId
FROM
  ThreadMemberships
LEFT JOIN
  Threads ON Threads.PostId = ThreadMemberships.PostId
JOIN
  PostsPriority ON PostsPriority.PostId = ThreadMemberships.PostId
WHERE
  PostsPriority.Priority = 'urgent'
  AND ThreadMemberships.UserId = '3cr5ori3d7ywunds8is6hu1wcy'
  AND ThreadMemberships.Following = true
  AND Threads.ThreadTeamId IN ('j4586eeb4py8pq6dqyj6gnmd4h')
  AND (
    Threads.ThreadDeleteAt IS NULL
    OR Threads.ThreadDeleteAt = 0
  )
GROUP BY
  Threads.ThreadTeamId;
```

- Since there are few posts matching ((priority)::text = ‘urgent’::text), this query is faster with `Nestedroop`.
```SQL
                                                                 QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------
 GroupAggregate  (cost=0.84..415.58 rows=1 width=56)
   Group Key: threads.threadteamid
   ->  Nested Loop  (cost=0.84..415.57 rows=1 width=32)
         ->  Nested Loop  (cost=0.42..400.32 rows=3 width=62)
               ->  Seq Scan on postspriority  (cost=0.00..3.51 rows=47 width=27)
                     Filter: ((priority)::text = 'urgent'::text)
               ->  Index Scan using threadmemberships_pkey on threadmemberships  (cost=0.42..8.44 rows=1 width=35)
                     Index Cond: (((postid)::text = (postspriority.postid)::text) AND ((userid)::text = '3cr5ori3d7ywunds8is6hu1wcy'::text))
                     Filter: following
         ->  Index Scan using threads_pkey on threads  (cost=0.42..5.08 rows=1 width=51)
               Index Cond: ((postid)::text = (threadmemberships.postid)::text)
               Filter: (((threaddeleteat IS NULL) OR (threaddeleteat = 0)) AND ((threadteamid)::text = 'j4586eeb4py8pq6dqyj6gnmd4h'::text))
(12 行)
```
