### PR TITLE
Reduce DB access from loadConfigAndMe

### DIFF
--- a/webapp/channels/src/components/root/actions/index.ts
+++ b/webapp/channels/src/components/root/actions/index.ts
@@ -67,7 +67,7 @@ export function loadConfigAndMe(): ThunkActionFunc<Promise<{isLoaded: boolean; i
                 dispatch(getMyTeamMembers()),
             ]);
 
-            dispatch(getMyTeamUnreads(isCollapsedThreadsEnabled(getState())));
+            dispatch(getMyTeamUnreads(false));
             dispatch(getServerLimits());
         } catch (error) {
             dispatch(logError(error as ServerError));


### PR DESCRIPTION
- https://github.com/stmninc/mattermost/pull/128
PR128において、リロード時のクエリC（A〜Eが何かは、Background参照）の発行削減を試みた。

このPRでは、リロード時に呼ばれる`loadConfigAndMe`内において`isCollapsedThreadsEnabled(getState() = false`にすることで、リロード時のクエリD、Eの発行削減を試みる。

https://github.com/stmninc/mattermost/blob/4ce434a9cf388a2fea82ab6be93b82aa15f6d52d/webapp/channels/src/components/root/actions/index.ts#L69-L70

## background
- https://github.com/stmninc/tunag-chat/issues/632#issuecomment-3601578091
クエリA〜Eの詳細については、こちらで調査してまとめている。

## verification
**Before**
<img width="1470" height="178" alt="image" src="https://github.com/user-attachments/assets/f4ee5483-e50c-4539-bf81-716e4b5e86cd" />

**After**
<img width="1470" height="191" alt="image" src="https://github.com/user-attachments/assets/0c2605ef-522b-4117-a52f-a08b35c9bebc" />
