### PR TITLE
feat: permission check in GetSidebarCategoriesForTeamUser

### DIFF
--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -47,6 +47,21 @@ func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID s
 		}
 	}
 
+	if !a.SessionHasPermissionToTeam(*c.Session(), teamID, model.PermissionCreatePrivateChannel) {
+		filteredCategories := make(model.SidebarCategoriesWithChannels, 0)
+		filteredOrder := make(model.SidebarCategoryOrder, 0)
+
+		for _, category := range categories.Categories {
+			if category.Type != model.SidebarCategoryDirectMessages {
+				filteredCategories = append(filteredCategories, category)
+				filteredOrder = append(filteredOrder, category.Id)
+			}
+		}
+
+		categories.Categories = filteredCategories
+		categories.Order = filteredOrder
+	}
+
 	return categories, nil
 }
 


### PR DESCRIPTION
- BASE Branch is https://github.com/stmninc/mattermost/pull/138

## Ticket
- https://github.com/stmninc/tunag-chat/issues/597

## Background
- https://github.com/stmninc/tunag-chat/issues/499?issue=stmninc%7Ctunag-chat%7C596

- This PR is refactor of #115 

## What changed from PR#115 
- I changed the implementation from the frontend to the backend for removing DMs from the sidebar categories.
By removing DMs from the list of sidebar category when permissions are lacking, the corresponding component automatically disappears on the frontend.