### PR TITLE
Add validation to fetching channels on BE to reflect DM/GM/unofficial setting

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -2113,16 +2113,33 @@ func (a *App) GetChannelsForUser(c request.CTX, userID string, includeDeleted bo
 		}
 	}
 
-	hasPermissionDM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateDirectChannel)
-	hasPermissionGM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateGroupChannel)
+// 	hasPermissionDM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateDirectChannel)
+// 	hasPermissionGM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateGroupChannel)
+// 	hasPermissionPrivate := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreatePrivateChannel)
+// 
+// 	if !hasPermissionDM || !hasPermissionGM || !hasPermissionPrivate {
+// 		filteredList := make(model.ChannelList, 0)
+// 
+// 		for _, channel := range list {
+// 			err := a.CheckChannelPermissions(c, channel, userID)
+// 			if err != nil {
+// 				continue
+// 			}
+// 			filteredList = append(filteredList, channel)
+// 		}
+// 		list = filteredList
+// 	}
+
+	// hasPermissionDM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateDirectChannel)
 	hasPermissionPrivate := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreatePrivateChannel)
 
-	if !hasPermissionDM || !hasPermissionGM || !hasPermissionPrivate {
+	if !hasPermissionPrivate {
 		filteredList := make(model.ChannelList, 0)
 
 		for _, channel := range list {
-			err := a.CheckChannelPermissions(c, channel, userID)
-			if err != nil {
+			if channel.Type == model.ChannelTypeDirect {
+				continue
+			} else if channel.Type == model.ChannelTypeGroup {
 				continue
 			}
 			filteredList = append(filteredList, channel)

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -2098,7 +2098,41 @@ func (s *Server) getChannelsForTeamForUser(c request.CTX, teamID string, userID 
 }
 
 func (a *App) GetChannelsForTeamForUser(c request.CTX, teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError) {
-	return a.Srv().getChannelsForTeamForUser(c, teamID, userID, opts)
+	list, err := a.Srv().getChannelsForTeamForUser(c, teamID, userID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	hasPermissionPrivate := true
+	session := *c.Session()
+
+	for _, teamMember := range session.TeamMembers {
+		if !a.SessionHasPermissionToTeam(*c.Session(), teamMember.TeamId, model.PermissionCreatePrivateChannel) {
+			hasPermissionPrivate = false
+			break
+		}
+	}
+
+	if !hasPermissionPrivate {
+		filteredList := make(model.ChannelList, 0)
+
+		for _, channel := range list {
+			if channel.Type == model.ChannelTypeDirect {
+				continue
+			} else if channel.Type == model.ChannelTypeGroup {
+				continue
+			} else if channel.Type == model.ChannelTypePrivate {
+				isOfficial, err := a.IsOfficialChannel(c, channel)
+				if err != nil || !isOfficial {
+					continue
+				}
+			}
+			filteredList = append(filteredList, channel)
+		}
+		list = filteredList
+	}
+
+	return list, nil
 }
 
 func (a *App) GetChannelsForUser(c request.CTX, userID string, includeDeleted bool, lastDeleteAt, pageSize int, fromChannelID string) (model.ChannelList, *model.AppError) {

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -2131,7 +2131,15 @@ func (a *App) GetChannelsForUser(c request.CTX, userID string, includeDeleted bo
 // 	}
 
 	// hasPermissionDM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateDirectChannel)
-	hasPermissionPrivate := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreatePrivateChannel)
+	hasPermissionPrivate := true
+	session := *c.Session()
+	
+	for _, teamMember := range session.TeamMembers {
+		if !a.SessionHasPermissionToTeam(*c.Session(), teamMember.TeamId, model.PermissionCreatePrivateChannel) {
+			hasPermissionPrivate = false
+			break
+		}
+	}
 
 	if !hasPermissionPrivate {
 		filteredList := make(model.ChannelList, 0)
@@ -2141,6 +2149,11 @@ func (a *App) GetChannelsForUser(c request.CTX, userID string, includeDeleted bo
 				continue
 			} else if channel.Type == model.ChannelTypeGroup {
 				continue
+			} else if channel.Type == model.ChannelTypePrivate {
+				isOfficial, err := a.IsOfficialChannel(c, channel)
+				if err != nil || !isOfficial {
+					continue
+				}
 			}
 			filteredList = append(filteredList, channel)
 		}

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -2113,6 +2113,23 @@ func (a *App) GetChannelsForUser(c request.CTX, userID string, includeDeleted bo
 		}
 	}
 
+	hasPermissionDM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateDirectChannel)
+	hasPermissionGM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateGroupChannel)
+	hasPermissionPrivate := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreatePrivateChannel)
+
+	if !hasPermissionDM || !hasPermissionGM || !hasPermissionPrivate {
+		filteredList := make(model.ChannelList, 0)
+
+		for _, channel := range list {
+			err := a.CheckChannelPermissions(c, channel, userID)
+			if err != nil {
+				continue
+			}
+			filteredList = append(filteredList, channel)
+		}
+		list = filteredList
+	}
+
 	return list, nil
 }
 

--- a/server/channels/app/role.go
+++ b/server/channels/app/role.go
@@ -157,6 +157,10 @@ func (a *App) PatchRole(role *model.Role, patch *model.RolePatch) (*model.Role, 
 		return nil, appErr
 	}
 
+	if appErr := a.Srv().InvalidateAllCaches(); appErr != nil {
+		return nil, appErr
+	}
+
 	return role, err
 }
 

--- a/server/channels/app/role.go
+++ b/server/channels/app/role.go
@@ -157,10 +157,6 @@ func (a *App) PatchRole(role *model.Role, patch *model.RolePatch) (*model.Role, 
 		return nil, appErr
 	}
 
-	if appErr := a.Srv().InvalidateAllCaches(); appErr != nil {
-		return nil, appErr
-	}
-
 	return role, err
 }
 


### PR DESCRIPTION
## Background
- https://github.com/stmninc/tunag-chat/issues/499
  - https://github.com/stmninc/tunag-chat/issues/499?issue=stmninc%7Ctunag-chat%7C597
  - https://github.com/stmninc/tunag-chat/issues/499?issue=stmninc%7Ctunag-chat%7C598

To ensure comprehensive support including mobile, I have shifted from UI-based changes to server-side validation.

## Implementation intention
`GetChannelsForTeamForUser` is called from mobile to fetch all channel belonging to current team, when starting application.

`GetChannelsForUser` is called from both webapp & mobile to fetch all channels belonging to all teams, 
when starting & reloading on webapp, 
and when a little time has passed since the app launched on mobile(to launch quickly).
