### PR TITLE
Feat/issue499 disable web UI

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -87,6 +87,7 @@ import useTextboxFocus from './use_textbox_focus';
 import useUploadFiles from './use_upload_files';
 
 import './advanced_text_editor.scss';
+import { useIsAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
 
 const FileLimitStickyBanner = makeAsyncComponent('FileLimitStickyBanner', lazy(() => import('components/file_limit_sticky_banner')));
 
@@ -226,7 +227,7 @@ const AdvancedTextEditor = ({
     const [renderScrollbar, setRenderScrollbar] = useState(false);
     const [keepEditorInFocus, setKeepEditorInFocus] = useState(false);
 
-    const readOnlyChannel = !canPost;
+    const readOnlyChannel = !canPost || !useIsAvailableUnofficialChannel(channelId);
     const hasDraftMessage = Boolean(draft.message);
     const showFormattingBar = !isFormattingBarHidden && !readOnlyChannel;
     const enableSharedChannelsDMs = useSelector((state: GlobalState) => getFeatureFlagValue(state, 'EnableSharedChannelsDMs') === 'true');

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -47,6 +47,7 @@ import {convertDisplayPositionToRawPosition, convertRawPositionToDisplayPosition
 import {OnboardingTourSteps, OnboardingTourStepsForGuestUsers, TutorialTourName} from 'components/tours/constant';
 import {SendMessageTour} from 'components/tours/onboarding_tour';
 
+import {isAvailableUnofficialChannel} from 'utils/available_unofficial_channel';
 import Constants, {
     Locations,
     StoragePrefixes,
@@ -87,8 +88,6 @@ import useTextboxFocus from './use_textbox_focus';
 import useUploadFiles from './use_upload_files';
 
 import './advanced_text_editor.scss';
-import { isAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
-import store from 'stores/redux_store';
 
 const FileLimitStickyBanner = makeAsyncComponent('FileLimitStickyBanner', lazy(() => import('components/file_limit_sticky_banner')));
 

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -87,7 +87,8 @@ import useTextboxFocus from './use_textbox_focus';
 import useUploadFiles from './use_upload_files';
 
 import './advanced_text_editor.scss';
-import { useIsAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
+import { isAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
+import store from 'stores/redux_store';
 
 const FileLimitStickyBanner = makeAsyncComponent('FileLimitStickyBanner', lazy(() => import('components/file_limit_sticky_banner')));
 
@@ -227,7 +228,7 @@ const AdvancedTextEditor = ({
     const [renderScrollbar, setRenderScrollbar] = useState(false);
     const [keepEditorInFocus, setKeepEditorInFocus] = useState(false);
 
-    const readOnlyChannel = !canPost || !useIsAvailableUnofficialChannel(channelId);
+    const readOnlyChannel = !canPost || !isAvailableUnofficialChannel(channelId);
     const hasDraftMessage = Boolean(draft.message);
     const showFormattingBar = !isFormattingBarHidden && !readOnlyChannel;
     const enableSharedChannelsDMs = useSelector((state: GlobalState) => getFeatureFlagValue(state, 'EnableSharedChannelsDMs') === 'true');

--- a/webapp/channels/src/components/channel_header/index.ts
+++ b/webapp/channels/src/components/channel_header/index.ts
@@ -106,7 +106,7 @@ function makeMapStateToProps() {
             isLastActiveEnabled,
             timestampUnits,
             hideGuestTags: config.HideGuestTags === 'true',
-            sharedChannelsPluginsEnabled: sharedChannelsPluginsEnabled,
+            sharedChannelsPluginsEnabled,
         };
     };
 }

--- a/webapp/channels/src/components/channel_header/index.ts
+++ b/webapp/channels/src/components/channel_header/index.ts
@@ -46,6 +46,7 @@ import {isFileAttachmentsEnabled} from 'utils/file_utils';
 import type {GlobalState} from 'types/store';
 
 import ChannelHeader from './channel_header';
+import { isAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
 
 function makeMapStateToProps() {
     const doGetProfilesInChannel = makeGetProfilesInChannel();
@@ -106,7 +107,7 @@ function makeMapStateToProps() {
             isLastActiveEnabled,
             timestampUnits,
             hideGuestTags: config.HideGuestTags === 'true',
-            sharedChannelsPluginsEnabled,
+            sharedChannelsPluginsEnabled: sharedChannelsPluginsEnabled && isAvailableUnofficialChannel(channel?.id || ''),
         };
     };
 }

--- a/webapp/channels/src/components/channel_header/index.ts
+++ b/webapp/channels/src/components/channel_header/index.ts
@@ -46,7 +46,6 @@ import {isFileAttachmentsEnabled} from 'utils/file_utils';
 import type {GlobalState} from 'types/store';
 
 import ChannelHeader from './channel_header';
-import { isAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
 
 function makeMapStateToProps() {
     const doGetProfilesInChannel = makeGetProfilesInChannel();
@@ -107,7 +106,7 @@ function makeMapStateToProps() {
             isLastActiveEnabled,
             timestampUnits,
             hideGuestTags: config.HideGuestTags === 'true',
-            sharedChannelsPluginsEnabled: sharedChannelsPluginsEnabled && isAvailableUnofficialChannel(channel?.id || ''),
+            sharedChannelsPluginsEnabled: sharedChannelsPluginsEnabled,
         };
     };
 }

--- a/webapp/channels/src/components/channel_members_rhs/member.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/member.tsx
@@ -20,6 +20,7 @@ import GuestTag from 'components/widgets/tag/guest_tag';
 import WithTooltip from 'components/with_tooltip';
 
 import type {ChannelMember as ChannelMemberType} from './member_list';
+import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
 
 interface Props {
     channel: Channel;
@@ -124,7 +125,7 @@ const Member = ({channel, member, index, totalUsers, editing, actions}: Props) =
                     />
                 )}
             </div>
-            {!editing && (
+            {!editing && isAvailableDMGMChannel() && (
                 <WithTooltip
                     title={formatMessage({
                         id: 'channel_members_rhs.member.send_message',

--- a/webapp/channels/src/components/channel_members_rhs/member.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/member.tsx
@@ -19,8 +19,9 @@ import SharedChannelIndicator from 'components/shared_channel_indicator';
 import GuestTag from 'components/widgets/tag/guest_tag';
 import WithTooltip from 'components/with_tooltip';
 
+import {isAvailableDMGMChannel} from 'utils/available_unofficial_channel';
+
 import type {ChannelMember as ChannelMemberType} from './member_list';
-import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
 
 interface Props {
     channel: Channel;

--- a/webapp/channels/src/components/dot_menu/dot_menu.test.tsx
+++ b/webapp/channels/src/components/dot_menu/dot_menu.test.tsx
@@ -14,9 +14,12 @@ import {TestHelper} from 'utils/test_helper';
 import type {GlobalState} from 'types/store';
 
 import DotMenu from './dot_menu';
-import type {DotMenuClass} from './dot_menu';
 
 jest.mock('./utils');
+
+jest.mock('utils/available_unofficial_channel', () => ({
+    isAvailableUnofficialChannel: jest.fn().mockReturnValue(true),
+}));
 
 describe('components/dot_menu/DotMenu', () => {
     const latestPost = {

--- a/webapp/channels/src/components/dot_menu/dot_menu.test.tsx
+++ b/webapp/channels/src/components/dot_menu/dot_menu.test.tsx
@@ -14,6 +14,7 @@ import {TestHelper} from 'utils/test_helper';
 import type {GlobalState} from 'types/store';
 
 import DotMenu from './dot_menu';
+import type {DotMenuClass} from './dot_menu';
 
 jest.mock('./utils');
 

--- a/webapp/channels/src/components/dot_menu/dot_menu.tsx
+++ b/webapp/channels/src/components/dot_menu/dot_menu.tsx
@@ -35,6 +35,7 @@ import * as Menu from 'components/menu';
 import MoveThreadModal from 'components/move_thread_modal';
 import ChannelPermissionGate from 'components/permissions_gates/channel_permission_gate';
 
+import {isAvailableUnofficialChannel} from 'utils/available_unofficial_channel';
 import {Locations, ModalIdentifiers, Constants, TELEMETRY_LABELS} from 'utils/constants';
 import DelayedAction from 'utils/delayed_action';
 import * as Keyboard from 'utils/keyboard';
@@ -677,7 +678,7 @@ export class DotMenuClass extends React.PureComponent<Props, State> {
                         onClick={this.copyText}
                     />
                 }
-                {this.state.canDelete &&
+                {isAvailableUnofficialChannel(this.props.post.channel_id) && this.state.canDelete &&
                     <Menu.Item
                         id={`delete_post_${this.props.post.id}`}
                         data-testid={`delete_post_${this.props.post.id}`}

--- a/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.test.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.test.tsx
@@ -10,6 +10,10 @@ import {TestHelper} from '../../../utils/test_helper';
 
 import CallButton, {isUserInCall} from './index';
 
+jest.mock('utils/available_unofficial_channel', () => ({
+    isAvailableUnofficialChannel: jest.fn().mockReturnValue(true),
+}));
+
 describe('isUserInCall', () => {
     test('missing state', () => {
         expect(isUserInCall({

--- a/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
@@ -23,7 +23,7 @@ import WithTooltip from 'components/with_tooltip';
 import {getDirectChannelName} from 'utils/utils';
 
 import type {GlobalState} from 'types/store';
-import { useIsAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
+import { isAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     userId: string;
@@ -96,7 +96,7 @@ const CallButton = ({
         return null;
     }
 
-    if (!useIsAvailableUnofficialChannel(dmChannel?.id || '')) {
+    if (!isAvailableUnofficialChannel(dmChannel?.id || '')) {
         return null;
     }
 

--- a/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
@@ -23,6 +23,7 @@ import WithTooltip from 'components/with_tooltip';
 import {getDirectChannelName} from 'utils/utils';
 
 import type {GlobalState} from 'types/store';
+import { useIsAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     userId: string;
@@ -92,6 +93,10 @@ const CallButton = ({
     });
 
     if (!shouldRenderButton) {
+        return null;
+    }
+
+    if (!useIsAvailableUnofficialChannel(dmChannel?.id || '')) {
         return null;
     }
 

--- a/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_call_button_wrapper/index.tsx
@@ -20,10 +20,10 @@ import {
 import ProfilePopoverCallButton from 'components/profile_popover/profile_popover_calls_button';
 import WithTooltip from 'components/with_tooltip';
 
+import {isAvailableUnofficialChannel} from 'utils/available_unofficial_channel';
 import {getDirectChannelName} from 'utils/utils';
 
 import type {GlobalState} from 'types/store';
-import { isAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     userId: string;

--- a/webapp/channels/src/components/profile_popover/profile_popover_other_user_row.test.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_other_user_row.test.tsx
@@ -11,6 +11,10 @@ import type {GlobalState} from 'types/store';
 
 import ProfilePopoverOtherUserRow from './profile_popover_other_user_row';
 
+jest.mock('utils/available_unofficial_channel', () => ({
+    isAvailableDMGMChannel: jest.fn().mockReturnValue(true),
+}));
+
 describe('components/ProfilePopoverOtherUserRow', () => {
     const baseProps = {
         user: TestHelper.getUserMock({id: 'user1'}),

--- a/webapp/channels/src/components/profile_popover/profile_popover_other_user_row.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_other_user_row.tsx
@@ -13,6 +13,7 @@ import ProfilePopoverAddToChannel from 'components/profile_popover/profile_popov
 import ProfilePopoverCallButtonWrapper from 'components/profile_popover/profile_popover_call_button_wrapper';
 
 import type {GlobalState} from 'types/store';
+import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     user: UserProfile;
@@ -43,7 +44,7 @@ const ProfilePopoverOtherUserRow = ({
 
     // Hide Message button for remote users when EnableSharedChannelsDMs feature flag is off
     const isRemoteUser = Boolean(user.remote_id);
-    const showMessageButton = isSharedChannelsDMsEnabled || !isRemoteUser;
+    const showMessageButton = (isSharedChannelsDMsEnabled || !isRemoteUser) && isAvailableDMGMChannel();
 
     return (
         <div className='user-popover__bottom-row-container'>

--- a/webapp/channels/src/components/profile_popover/profile_popover_other_user_row.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_other_user_row.tsx
@@ -12,8 +12,9 @@ import {getFeatureFlagValue} from 'mattermost-redux/selectors/entities/general';
 import ProfilePopoverAddToChannel from 'components/profile_popover/profile_popover_add_to_channel';
 import ProfilePopoverCallButtonWrapper from 'components/profile_popover/profile_popover_call_button_wrapper';
 
+import {isAvailableDMGMChannel} from 'utils/available_unofficial_channel';
+
 import type {GlobalState} from 'types/store';
-import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     user: UserProfile;

--- a/webapp/channels/src/components/profile_popover/profile_popover_self_user_row.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_self_user_row.tsx
@@ -10,6 +10,7 @@ import {openModal} from 'actions/views/modals';
 import UserSettingsModal from 'components/user_settings/modal';
 import WithTooltip from 'components/with_tooltip';
 
+import {isAvailableDMGMChannel} from 'utils/available_unofficial_channel';
 import {ModalIdentifiers} from 'utils/constants';
 
 type Props = {
@@ -66,21 +67,23 @@ const ProfilePopoverSelfUserRow = ({
                     defaultMessage='Edit Profile'
                 />
             </button>
-            <WithTooltip
-                title={formatMessage({id: 'user_profile.send.dm.yourself', defaultMessage: 'Send yourself a message'})}
-            >
-                <button
-                    type='button'
-                    className='btn btn-icon btn-sm'
-                    onClick={handleShowDirectChannel}
-                    aria-label={formatMessage({id: 'user_profile.send.dm.yourself', defaultMessage: 'Send yourself a message'})}
+            {isAvailableDMGMChannel() && (
+                <WithTooltip
+                    title={formatMessage({id: 'user_profile.send.dm.yourself', defaultMessage: 'Send yourself a message'})}
                 >
-                    <i
-                        className='icon icon-send'
-                        aria-hidden='true'
-                    />
-                </button>
-            </WithTooltip>
+                    <button
+                        type='button'
+                        className='btn btn-icon btn-sm'
+                        onClick={handleShowDirectChannel}
+                        aria-label={formatMessage({id: 'user_profile.send.dm.yourself', defaultMessage: 'Send yourself a message'})}
+                    >
+                        <i
+                            className='icon icon-send'
+                            aria-hidden='true'
+                        />
+                    </button>
+                </WithTooltip>
+            )}
         </div>
     );
 };

--- a/webapp/channels/src/components/root/actions/index.ts
+++ b/webapp/channels/src/components/root/actions/index.ts
@@ -15,8 +15,7 @@ import {getMyTeamMembers, getMyTeams, getMyTeamUnreads} from 'mattermost-redux/a
 import {getMe, getProfiles} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {General} from 'mattermost-redux/constants';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import {isCollapsedThreadsEnabled, getIsOnboardingFlowEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {getIsOnboardingFlowEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getActiveTeamsList} from 'mattermost-redux/selectors/entities/teams';
 import {checkIsFirstAdmin, getCurrentUser, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 

--- a/webapp/channels/src/components/root/actions/index.ts
+++ b/webapp/channels/src/components/root/actions/index.ts
@@ -15,6 +15,7 @@ import {getMyTeamMembers, getMyTeams, getMyTeamUnreads} from 'mattermost-redux/a
 import {getMe, getProfiles} from 'mattermost-redux/actions/users';
 import {Client4} from 'mattermost-redux/client';
 import {General} from 'mattermost-redux/constants';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import {isCollapsedThreadsEnabled, getIsOnboardingFlowEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getActiveTeamsList} from 'mattermost-redux/selectors/entities/teams';
 import {checkIsFirstAdmin, getCurrentUser, isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.test.tsx
@@ -10,6 +10,10 @@ import {CategoryTypes} from 'mattermost-redux/constants/channel_categories';
 
 import SidebarCategory from 'components/sidebar/sidebar_category/sidebar_category';
 
+jest.mock('utils/available_unofficial_channel', () => ({
+    isAvailableDMGMChannel: jest.fn().mockReturnValue(true),
+}));
+
 describe('components/sidebar/sidebar_category', () => {
     const baseProps = {
         category: {
@@ -121,7 +125,7 @@ describe('components/sidebar/sidebar_category', () => {
         expect(droppableInner).toMatchSnapshot();
     });
 
-    test('should match snapshot when the category is DM and there are no DMs to display', () => {
+    xtest('should match snapshot when the category is DM and there are no DMs to display', () => {
         const props = {
             ...baseProps,
             category: {

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.test.tsx
@@ -125,7 +125,7 @@ describe('components/sidebar/sidebar_category', () => {
         expect(droppableInner).toMatchSnapshot();
     });
 
-    xtest('should match snapshot when the category is DM and there are no DMs to display', () => {
+    test('should match snapshot when the category is DM and there are no DMs to display', () => {
         const props = {
             ...baseProps,
             category: {

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -33,6 +33,7 @@ import AddChannelsCtaButton from '../add_channels_cta_button';
 import InviteMembersButton from '../invite_members_button';
 import {SidebarCategoryHeader} from '../sidebar_category_header';
 import SidebarChannel from '../sidebar_channel';
+import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     category: ChannelCategory;
@@ -275,7 +276,7 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                         category={category}
                         handleOpenDirectMessagesModal={this.handleOpenDirectMessagesModal}
                     />
-                    <WithTooltip
+                    {isAvailableDMGMChannel() && (<WithTooltip
                         title={
                             <>
                                 {addHelpLabel}
@@ -295,7 +296,7 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                         >
                             <i className='icon-plus'/>
                         </button>
-                    </WithTooltip>
+                    </WithTooltip>)}
                 </>
             );
 

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -270,6 +270,11 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
         } else if (category.type === CategoryTypes.DIRECT_MESSAGES) {
             const addHelpLabel = localizeMessage({id: 'sidebar.createDirectMessage', defaultMessage: 'Create new direct message'});
 
+            // Only show the direct message category if there are channels in the category
+            if (!channelIds || !channelIds.length) {
+                return null;
+            }
+
             categoryMenu = (
                 <>
                     <SidebarCategorySortingMenu

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -270,11 +270,6 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
         } else if (category.type === CategoryTypes.DIRECT_MESSAGES) {
             const addHelpLabel = localizeMessage({id: 'sidebar.createDirectMessage', defaultMessage: 'Create new direct message'});
 
-            // Only show the direct message category if there are channels in the category
-            if (!channelIds || !channelIds.length) {
-                return null;
-            }
-
             categoryMenu = (
                 <>
                     <SidebarCategorySortingMenu

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category.tsx
@@ -21,6 +21,7 @@ import KeyboardShortcutSequence, {
 } from 'components/keyboard_shortcuts/keyboard_shortcuts_sequence';
 import WithTooltip from 'components/with_tooltip';
 
+import {isAvailableDMGMChannel} from 'utils/available_unofficial_channel';
 import Constants, {A11yCustomEventTypes, DraggingStateTypes, DraggingStates} from 'utils/constants';
 import {isKeyPressed} from 'utils/keyboard';
 
@@ -33,7 +34,6 @@ import AddChannelsCtaButton from '../add_channels_cta_button';
 import InviteMembersButton from '../invite_members_button';
 import {SidebarCategoryHeader} from '../sidebar_category_header';
 import SidebarChannel from '../sidebar_channel';
-import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     category: ChannelCategory;
@@ -281,27 +281,28 @@ export default class SidebarCategory extends React.PureComponent<Props, State> {
                         category={category}
                         handleOpenDirectMessagesModal={this.handleOpenDirectMessagesModal}
                     />
-                    {isAvailableDMGMChannel() && (<WithTooltip
-                        title={
-                            <>
-                                {addHelpLabel}
-                                <KeyboardShortcutSequence
-                                    shortcut={KEYBOARD_SHORTCUTS.navDMMenu}
-                                    hideDescription={true}
-                                    isInsideTooltip={true}
-                                />
-                            </>
-                        }
-                    >
-                        <button
-                            id='newDirectMessageButton'
-                            className='SidebarChannelGroupHeader_addButton'
-                            onClick={this.handleOpenDirectMessagesModal}
-                            aria-label={addHelpLabel}
+                    {isAvailableDMGMChannel() && (
+                        <WithTooltip
+                            title={
+                                <>
+                                    {addHelpLabel}
+                                    <KeyboardShortcutSequence
+                                        shortcut={KEYBOARD_SHORTCUTS.navDMMenu}
+                                        hideDescription={true}
+                                        isInsideTooltip={true}
+                                    />
+                                </>
+                            }
                         >
-                            <i className='icon-plus'/>
-                        </button>
-                    </WithTooltip>)}
+                            <button
+                                id='newDirectMessageButton'
+                                className='SidebarChannelGroupHeader_addButton'
+                                onClick={this.handleOpenDirectMessagesModal}
+                                aria-label={addHelpLabel}
+                            >
+                                <i className='icon-plus'/>
+                            </button>
+                        </WithTooltip>)}
                 </>
             );
 

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_sorting_menu.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_sorting_menu.test.tsx
@@ -9,6 +9,10 @@ import {TestHelper} from 'utils/test_helper';
 
 import SidebarCategorySortingMenu from './sidebar_category_sorting_menu';
 
+jest.mock('utils/available_unofficial_channel', () => ({
+    isAvailableDMGMChannel: jest.fn().mockReturnValue(true),
+}));
+
 const initialState = {
     entities: {
         users: {

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_sorting_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_sorting_menu.tsx
@@ -30,6 +30,7 @@ import {trackEvent} from 'actions/telemetry_actions';
 import * as Menu from 'components/menu';
 
 import Constants from 'utils/constants';
+import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     category: ChannelCategory;
@@ -210,7 +211,7 @@ const SidebarCategorySortingMenu = ({
                 {sortDirectMessagesMenuItem}
                 {showMessagesCountMenuItem}
                 <Menu.Separator/>
-                {openDirectMessageMenuItem}
+                {isAvailableDMGMChannel() && openDirectMessageMenuItem}
             </Menu.Container>
         </div>
     );

--- a/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_sorting_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_category/sidebar_category_sorting_menu.tsx
@@ -29,8 +29,8 @@ import {trackEvent} from 'actions/telemetry_actions';
 
 import * as Menu from 'components/menu';
 
+import {isAvailableDMGMChannel} from 'utils/available_unofficial_channel';
 import Constants from 'utils/constants';
-import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     category: ChannelCategory;

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_browse_or_add_channel_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_browse_or_add_channel_menu.tsx
@@ -16,7 +16,8 @@ import {
 import * as Menu from 'components/menu';
 import {OnboardingTourSteps} from 'components/tours';
 import {useShowOnboardingTutorialStep, CreateAndJoinChannelsTour, InvitePeopleTour} from 'components/tours/onboarding_tour';
-import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
+
+import {isAvailableDMGMChannel} from 'utils/available_unofficial_channel';
 
 export const ELEMENT_ID_FOR_BROWSE_OR_ADD_CHANNEL_MENU = 'browserOrAddChannelMenu';
 export const ELEMENT_ID_FOR_BROWSE_OR_ADD_CHANNEL_MENU_BUTTON = 'browseOrAddChannelMenuButton';

--- a/webapp/channels/src/components/sidebar/sidebar_header/sidebar_browse_or_add_channel_menu.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_header/sidebar_browse_or_add_channel_menu.tsx
@@ -16,6 +16,7 @@ import {
 import * as Menu from 'components/menu';
 import {OnboardingTourSteps} from 'components/tours';
 import {useShowOnboardingTutorialStep, CreateAndJoinChannelsTour, InvitePeopleTour} from 'components/tours/onboarding_tour';
+import { isAvailableDMGMChannel } from 'utils/available_unofficial_channel';
 
 export const ELEMENT_ID_FOR_BROWSE_OR_ADD_CHANNEL_MENU = 'browserOrAddChannelMenu';
 export const ELEMENT_ID_FOR_BROWSE_OR_ADD_CHANNEL_MENU_BUTTON = 'browseOrAddChannelMenuButton';
@@ -170,7 +171,7 @@ export default function SidebarBrowserOrAddChannelMenu(props: Props) {
         >
             {createNewChannelMenuItem}
             {browseChannelsMenuItem}
-            {createDirectMessageMenuItem}
+            {isAvailableDMGMChannel() && createDirectMessageMenuItem}
             {createUserGroupMenuItem}
             {Boolean(createNewCategoryMenuItem) &&
                 <Menu.Separator/>

--- a/webapp/channels/src/plugins/call_button/call_button.tsx
+++ b/webapp/channels/src/plugins/call_button/call_button.tsx
@@ -13,12 +13,12 @@ import type {Channel, ChannelMembership} from '@mattermost/types/channels';
 import Menu from 'components/widgets/menu/menu';
 import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 
+import {isAvailableUnofficialChannel} from 'utils/available_unofficial_channel';
 import {Constants} from 'utils/constants';
 
 import type {CallButtonAction} from 'types/store/plugins';
 
 import './call_button.scss';
-import { isAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     currentChannel?: Channel;

--- a/webapp/channels/src/plugins/call_button/call_button.tsx
+++ b/webapp/channels/src/plugins/call_button/call_button.tsx
@@ -18,6 +18,7 @@ import {Constants} from 'utils/constants';
 import type {CallButtonAction} from 'types/store/plugins';
 
 import './call_button.scss';
+import { isAvailableUnofficialChannel } from 'utils/available_unofficial_channel';
 
 type Props = {
     currentChannel?: Channel;
@@ -42,7 +43,7 @@ export default function CallButton({pluginCallComponents, currentChannel, channe
         prevSidebarOpen.current = sidebarOpen;
     }, [sidebarOpen]);
 
-    if (pluginCallComponents.length === 0) {
+    if (pluginCallComponents.length === 0 || !isAvailableUnofficialChannel(currentChannel?.id || '')) {
         return null;
     }
 

--- a/webapp/channels/src/utils/available_unofficial_channel.test.ts
+++ b/webapp/channels/src/utils/available_unofficial_channel.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Permissions} from 'mattermost-redux/constants';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {haveIChannelPermission, haveICurrentTeamPermission} from 'mattermost-redux/selectors/entities/roles';
+
+import store from 'stores/redux_store';
+
+import {isAvailableUnofficialChannel, isAvailableDMGMChannel} from './available_unofficial_channel';
+import {isOfficialTunagChannel} from './official_channel_utils';
+
+jest.mock('stores/redux_store', () => ({
+    getState: jest.fn(),
+}));
+
+jest.mock('mattermost-redux/selectors/entities/channels', () => ({
+    ...jest.requireActual('mattermost-redux/selectors/entities/channels'),
+    getChannel: jest.fn(),
+}));
+
+jest.mock('mattermost-redux/selectors/entities/roles', () => ({
+    ...jest.requireActual('mattermost-redux/selectors/entities/roles'),
+    haveIChannelPermission: jest.fn(),
+    haveICurrentTeamPermission: jest.fn(),
+}));
+
+jest.mock('./official_channel_utils', () => ({
+    ...jest.requireActual('./official_channel_utils'),
+    isOfficialTunagChannel: jest.fn(),
+}));
+
+let mockChannel: any;
+let mockIsOfficial: boolean;
+let mockPermissionResult: boolean;
+
+describe('available_unofficial_channel utils', () => {
+    // Cast mock functions for easier usage
+    const mockGetState = store.getState as jest.Mock;
+    const mockGetChannel = getChannel as jest.Mock;
+    const mockHaveIChannelPermission = haveIChannelPermission as jest.Mock;
+    const mockHaveICurrentTeamPermission = haveICurrentTeamPermission as jest.Mock;
+    const mockIsOfficialTunagChannelFn = isOfficialTunagChannel as jest.Mock;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+
+        // Initialize variables
+        mockChannel = {id: 'channel_id', team_id: 'team_id', type: 'O'};
+        mockIsOfficial = false;
+        mockPermissionResult = true; // Default to having permission
+
+        // Setup mock behavior
+        mockGetState.mockReturnValue({});
+        mockGetChannel.mockImplementation(() => mockChannel);
+        mockIsOfficialTunagChannelFn.mockImplementation(() => mockIsOfficial);
+
+        // Simplify permission check to return mockPermissionResult
+        // (Set mockPermissionResult to false in individual test cases to simulate denial)
+        mockHaveIChannelPermission.mockImplementation(() => mockPermissionResult);
+        mockHaveICurrentTeamPermission.mockImplementation(() => mockPermissionResult);
+    });
+
+    describe('isAvailableUnofficialChannel', () => {
+        test('should return false when channel does not exist', () => {
+            mockGetChannel.mockReturnValue(null);
+            expect(isAvailableUnofficialChannel('missing_channel')).toBe(false);
+        });
+
+        test('should return true for official Tunag channel without permission check', () => {
+            mockIsOfficial = true;
+            mockPermissionResult = false;
+
+            expect(isAvailableUnofficialChannel('channel_id')).toBe(true);
+            expect(mockIsOfficialTunagChannelFn).toHaveBeenCalledWith(mockChannel);
+            expect(mockHaveIChannelPermission).not.toHaveBeenCalled();
+        });
+
+        test('should return true for open channel type (Type: O) or default cases', () => {
+            mockChannel.type = 'O'; // Open
+            expect(isAvailableUnofficialChannel('channel_id')).toBe(true);
+
+            mockChannel.type = 'StrangeType'; // Default case check
+            expect(isAvailableUnofficialChannel('channel_id')).toBe(true);
+
+            // Permission check function should not be called in default case
+            expect(mockHaveIChannelPermission).not.toHaveBeenCalled();
+        });
+
+        test('should check CREATE_PRIVATE_CHANNEL permission for private channel (Type: P)', () => {
+            mockChannel.type = 'P';
+            mockPermissionResult = true;
+
+            expect(isAvailableUnofficialChannel('channel_id')).toBe(true);
+            expect(mockHaveIChannelPermission).toHaveBeenCalledWith(
+                expect.anything(),
+                'team_id',
+                'channel_id',
+                Permissions.CREATE_PRIVATE_CHANNEL,
+            );
+        });
+
+        test('should check CREATE_DIRECT_CHANNEL permission for direct message (Type: D)', () => {
+            mockChannel.type = 'D';
+
+            expect(isAvailableUnofficialChannel('channel_id')).toBe(true);
+            expect(mockHaveIChannelPermission).toHaveBeenCalledWith(
+                expect.anything(),
+                'team_id',
+                'channel_id',
+                Permissions.CREATE_DIRECT_CHANNEL,
+            );
+        });
+
+        test('should check CREATE_GROUP_CHANNEL permission for group message (Type: G)', () => {
+            mockChannel.type = 'G';
+
+            expect(isAvailableUnofficialChannel('channel_id')).toBe(true);
+            expect(mockHaveIChannelPermission).toHaveBeenCalledWith(
+                expect.anything(),
+                'team_id',
+                'channel_id',
+                Permissions.CREATE_GROUP_CHANNEL,
+            );
+        });
+
+        test('should return false when permission is denied', () => {
+            mockChannel.type = 'P';
+            mockPermissionResult = false; // Permission denied
+
+            expect(isAvailableUnofficialChannel('channel_id')).toBe(false);
+        });
+    });
+
+    describe('isAvailableDMGMChannel', () => {
+        test('should return true when both DM and GM creation permissions are granted', () => {
+            mockPermissionResult = true;
+            expect(isAvailableDMGMChannel()).toBe(true);
+
+            expect(mockHaveICurrentTeamPermission).toHaveBeenCalledWith(expect.anything(), Permissions.CREATE_DIRECT_CHANNEL);
+            expect(mockHaveICurrentTeamPermission).toHaveBeenCalledWith(expect.anything(), Permissions.CREATE_GROUP_CHANNEL);
+        });
+
+        test('should return false when DM creation permission is denied', () => {
+            // Change return value for each call: 1st(DM) is False, 2nd(GM) is True
+            mockHaveICurrentTeamPermission.
+                mockReturnValueOnce(false).
+                mockReturnValueOnce(true);
+
+            expect(isAvailableDMGMChannel()).toBe(false);
+        });
+
+        test('should return false when GM creation permission is denied', () => {
+            // Change return value for each call: 1st(DM) is True, 2nd(GM) is False
+            mockHaveICurrentTeamPermission.
+                mockReturnValueOnce(true).
+                mockReturnValueOnce(false);
+
+            expect(isAvailableDMGMChannel()).toBe(false);
+        });
+    });
+});

--- a/webapp/channels/src/utils/available_unofficial_channel.ts
+++ b/webapp/channels/src/utils/available_unofficial_channel.ts
@@ -1,7 +1,7 @@
 import { getChannel } from "mattermost-redux/selectors/entities/channels";
 import { isOfficialTunagChannel } from "./official_channel_utils";
 import {Permissions} from 'mattermost-redux/constants';
-import { haveIChannelPermission } from "mattermost-redux/selectors/entities/roles";
+import { haveIChannelPermission, haveICurrentTeamPermission } from "mattermost-redux/selectors/entities/roles";
 import store from 'stores/redux_store';
 
 export const isAvailableUnofficialChannel = (channelId: string): boolean => {
@@ -33,4 +33,9 @@ export const isAvailableUnofficialChannel = (channelId: string): boolean => {
     }
 
     return haveIChannelPermission(state, channel.team_id, channel.id, permission); 
+}
+
+export const isAvailableDMGMChannel = (): boolean => {
+    const state = store.getState();
+    return haveICurrentTeamPermission(state, Permissions.CREATE_DIRECT_CHANNEL) && haveICurrentTeamPermission(state, Permissions.CREATE_GROUP_CHANNEL);
 }

--- a/webapp/channels/src/utils/available_unofficial_channel.ts
+++ b/webapp/channels/src/utils/available_unofficial_channel.ts
@@ -1,28 +1,24 @@
 import { getChannel } from "mattermost-redux/selectors/entities/channels";
-import { useSelector } from "react-redux";
-import { GlobalState } from "types/store";
 import { isOfficialTunagChannel } from "./official_channel_utils";
 import {Permissions} from 'mattermost-redux/constants';
 import { haveIChannelPermission } from "mattermost-redux/selectors/entities/roles";
+import store from 'stores/redux_store';
 
+export const isAvailableUnofficialChannel = (channelId: string): boolean => {
+    const state = store.getState();
+    const channel = getChannel(state, channelId);
+    
+    if (!channel) {
+        return false;
+    }
 
-export const useIsAvailableUnofficialChannel = (channelId: string): boolean => {
-    return useSelector((state: GlobalState) => {
-        const channel = getChannel(state, channelId);
+    if (isOfficialTunagChannel(channel)) {
+        return true;
+    }
 
-        if (!channel) {
-            return false;
-        }
+    let permission: string | undefined;
 
-        const isOfficial = isOfficialTunagChannel(channel);
-
-        if (isOfficial) {
-            return true;
-        }
-
-        let permission: string;
-
-        switch (channel.type) {
+    switch (channel.type) {
         case 'P':
             permission = Permissions.CREATE_PRIVATE_CHANNEL;
             break;
@@ -34,8 +30,7 @@ export const useIsAvailableUnofficialChannel = (channelId: string): boolean => {
             break;
         default:
             return true;
-        }
+    }
 
-        return haveIChannelPermission(state, channel.team_id, channel.id, permission);
-    });
+    return haveIChannelPermission(state, channel.team_id, channel.id, permission); 
 }

--- a/webapp/channels/src/utils/available_unofficial_channel.ts
+++ b/webapp/channels/src/utils/available_unofficial_channel.ts
@@ -1,13 +1,17 @@
-import { getChannel } from "mattermost-redux/selectors/entities/channels";
-import { isOfficialTunagChannel } from "./official_channel_utils";
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 import {Permissions} from 'mattermost-redux/constants';
-import { haveIChannelPermission, haveICurrentTeamPermission } from "mattermost-redux/selectors/entities/roles";
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {haveIChannelPermission, haveICurrentTeamPermission} from 'mattermost-redux/selectors/entities/roles';
+
 import store from 'stores/redux_store';
+
+import {isOfficialTunagChannel} from './official_channel_utils';
 
 export const isAvailableUnofficialChannel = (channelId: string): boolean => {
     const state = store.getState();
     const channel = getChannel(state, channelId);
-    
     if (!channel) {
         return false;
     }
@@ -19,23 +23,23 @@ export const isAvailableUnofficialChannel = (channelId: string): boolean => {
     let permission: string | undefined;
 
     switch (channel.type) {
-        case 'P':
-            permission = Permissions.CREATE_PRIVATE_CHANNEL;
-            break;
-        case 'D':
-            permission = Permissions.CREATE_DIRECT_CHANNEL;
-            break;
-        case 'G':
-            permission = Permissions.CREATE_GROUP_CHANNEL;
-            break;
-        default:
-            return true;
+    case 'P':
+        permission = Permissions.CREATE_PRIVATE_CHANNEL;
+        break;
+    case 'D':
+        permission = Permissions.CREATE_DIRECT_CHANNEL;
+        break;
+    case 'G':
+        permission = Permissions.CREATE_GROUP_CHANNEL;
+        break;
+    default:
+        return true;
     }
 
-    return haveIChannelPermission(state, channel.team_id, channel.id, permission); 
-}
+    return haveIChannelPermission(state, channel.team_id, channel.id, permission);
+};
 
 export const isAvailableDMGMChannel = (): boolean => {
     const state = store.getState();
     return haveICurrentTeamPermission(state, Permissions.CREATE_DIRECT_CHANNEL) && haveICurrentTeamPermission(state, Permissions.CREATE_GROUP_CHANNEL);
-}
+};

--- a/webapp/channels/src/utils/available_unofficial_channel.ts
+++ b/webapp/channels/src/utils/available_unofficial_channel.ts
@@ -1,0 +1,41 @@
+import { getChannel } from "mattermost-redux/selectors/entities/channels";
+import { useSelector } from "react-redux";
+import { GlobalState } from "types/store";
+import { isOfficialTunagChannel } from "./official_channel_utils";
+import {Permissions} from 'mattermost-redux/constants';
+import { haveIChannelPermission } from "mattermost-redux/selectors/entities/roles";
+
+
+export const useIsAvailableUnofficialChannel = (channelId: string): boolean => {
+    return useSelector((state: GlobalState) => {
+        const channel = getChannel(state, channelId);
+
+        if (!channel) {
+            return false;
+        }
+
+        const isOfficial = isOfficialTunagChannel(channel);
+
+        if (isOfficial) {
+            return true;
+        }
+
+        let permission: string;
+
+        switch (channel.type) {
+        case 'P':
+            permission = Permissions.CREATE_PRIVATE_CHANNEL;
+            break;
+        case 'D':
+            permission = Permissions.CREATE_DIRECT_CHANNEL;
+            break;
+        case 'G':
+            permission = Permissions.CREATE_GROUP_CHANNEL;
+            break;
+        default:
+            return true;
+        }
+
+        return haveIChannelPermission(state, channel.team_id, channel.id, permission);
+    });
+}


### PR DESCRIPTION
## Background 
- https://github.com/stmninc/tunag-chat/issues/499

## Summary
Channels DM, GM, or not created via TUNAG (unofficially created by users) are defined as "**unofficial channels**".

If settings on TUNAG to prevent the creation of "unofficial channels", operations on these channel groups will be prohibited via the WebUI.

## Feature
- `isAvailableUnofficialChannel` 
Function to determine whether the current channel is permitted

- `isAvailableDMGMChannel`
Function to determine whether DMGM is permitted

- Add validation using the above function to the UI to restrict "unofficial channels"

 ### Text box
<img width=50% alt="image" src="https://github.com/user-attachments/assets/8a4071ad-87ed-4575-96e4-80a7f938e7ce" />

### DM button in member-console (Before -> After)

<img width=35% alt="image" src="https://github.com/user-attachments/assets/cdb4d769-f885-4b27-809b-41cc107a8c7f" />
<img width=35% alt="image" src="https://github.com/user-attachments/assets/8e544954-f443-4e51-ae35-81b2132af591" />

### Delete bottun in dot menu (Before -> After)

<img width=35% alt="image" src="https://github.com/user-attachments/assets/b62f5b7d-1583-4784-b572-ebdb47e8087f" />
<img width=35% alt="image" src="https://github.com/user-attachments/assets/a206d43d-aedc-414c-8e1f-3c79c4be915b" />

### My profile popover (Before -> After)

<img width=33% alt="image" src="https://github.com/user-attachments/assets/e3e3dc73-e470-4cf6-96e2-9523e24eba26" />
<img width=35% alt="image" src="https://github.com/user-attachments/assets/159b5af2-6a6b-4f1f-8f11-3e65b13f0a6c" />

### Their profile popover (Before -> After)
<img width=35% alt="image" src="https://github.com/user-attachments/assets/c142dc60-8d6a-47c3-abdb-00f4c3fe8338" />
<img width=35% alt="image" src="https://github.com/user-attachments/assets/94464b55-62a2-4c32-8429-19551f0c0fb5" />

### DM in sidebar (Before -> After)
<img width=40% alt="image" src="https://github.com/user-attachments/assets/50a61a82-0150-4f2e-8e71-fad256aedb4f" />
<img width=40% alt="image" src="https://github.com/user-attachments/assets/83abcd6b-fa1c-41d9-bd41-194ebda0bc30" />

### Call button
テスト環境にプラグイン導入不可のため画像なし






