### PR TITLE
Feat/issue499 disable DM category in backend

### DIFF
--- a/server/channels/api4/channel_category.go
+++ b/server/channels/api4/channel_category.go
@@ -29,6 +29,8 @@ func getCategoriesForTeamForUser(c *Context, w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	c.App.FilterSidebarCategories(c.AppContext, categories)
+
 	categoriesJSON, err := json.Marshal(categories)
 	if err != nil {
 		c.Err = model.NewAppError("getCategoriesForTeamForUser", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -47,6 +47,21 @@ func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID s
 		}
 	}
 
+	// If DM category contains no channels, do not return DM category
+	filteredCategories := make(model.SidebarCategoriesWithChannels, 0)
+	filteredOrder := make(model.SidebarCategoryOrder, 0)
+
+	for _, category := range categories.Categories {
+		if category.Type == model.SidebarCategoryDirectMessages && len(category.Channels) == 0 {
+			continue
+		}
+		filteredCategories = append(filteredCategories, category)
+		filteredOrder = append(filteredOrder, category.Id)
+	}
+
+	categories.Categories = filteredCategories
+	categories.Order = filteredOrder
+
 	return categories, nil
 }
 

--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -49,7 +49,7 @@ func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID s
 
 	session := c.Session()
 	// for testuser
-	if len(session.Roles) == 0 {
+	if session.Roles == "" {
 		return categories, nil
 	}
 

--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -47,20 +47,25 @@ func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID s
 		}
 	}
 
-	// If DM category contains no channels, do not return DM category
-	filteredCategories := make(model.SidebarCategoriesWithChannels, 0)
-	filteredOrder := make(model.SidebarCategoryOrder, 0)
+	hasPermissionDM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateDirectChannel)
+	hasPermissionGM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateGroupChannel)
 
-	for _, category := range categories.Categories {
-		if category.Type == model.SidebarCategoryDirectMessages && len(category.Channels) == 0 {
-			continue
+	if !hasPermissionDM && !hasPermissionGM {
+		// If DM category contains no channels, do not return DM category
+		filteredCategories := make(model.SidebarCategoriesWithChannels, 0)
+		filteredOrder := make(model.SidebarCategoryOrder, 0)
+
+		for _, category := range categories.Categories {
+			if category.Type == model.SidebarCategoryDirectMessages && len(category.Channels) == 0 {
+				continue
+			}
+			filteredCategories = append(filteredCategories, category)
+			filteredOrder = append(filteredOrder, category.Id)
 		}
-		filteredCategories = append(filteredCategories, category)
-		filteredOrder = append(filteredOrder, category.Id)
-	}
 
-	categories.Categories = filteredCategories
-	categories.Order = filteredOrder
+		categories.Categories = filteredCategories
+		categories.Order = filteredOrder
+	}
 
 	return categories, nil
 }

--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -47,31 +47,7 @@ func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID s
 		}
 	}
 
-	session := c.Session()
-	// for testuser
-	if session.Roles == "" {
-		return categories, nil
-	}
-
-	hasPermissionDM := a.SessionHasPermissionTo(*session, model.PermissionCreateDirectChannel)
-	hasPermissionGM := a.SessionHasPermissionTo(*session, model.PermissionCreateGroupChannel)
-
-	if !hasPermissionDM && !hasPermissionGM {
-		filteredCategories := make(model.SidebarCategoriesWithChannels, 0)
-		filteredOrder := make(model.SidebarCategoryOrder, 0)
-
-		for _, category := range categories.Categories {
-			// If DM category contains no channels, do not return DM category
-			if category.Type == model.SidebarCategoryDirectMessages && len(category.Channels) == 0 {
-				continue
-			}
-			filteredCategories = append(filteredCategories, category)
-			filteredOrder = append(filteredOrder, category.Id)
-		}
-
-		categories.Categories = filteredCategories
-		categories.Order = filteredOrder
-	}
+	a.filterSidebarCategories(c, categories)
 
 	return categories, nil
 }

--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -47,15 +47,21 @@ func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID s
 		}
 	}
 
-	hasPermissionDM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateDirectChannel)
-	hasPermissionGM := a.SessionHasPermissionTo(*c.Session(), model.PermissionCreateGroupChannel)
+	session := c.Session()
+	// for testuser
+	if len(session.Roles) == 0 {
+		return categories, nil
+	}
+
+	hasPermissionDM := a.SessionHasPermissionTo(*session, model.PermissionCreateDirectChannel)
+	hasPermissionGM := a.SessionHasPermissionTo(*session, model.PermissionCreateGroupChannel)
 
 	if !hasPermissionDM && !hasPermissionGM {
-		// If DM category contains no channels, do not return DM category
 		filteredCategories := make(model.SidebarCategoriesWithChannels, 0)
 		filteredOrder := make(model.SidebarCategoryOrder, 0)
 
 		for _, category := range categories.Categories {
+			// If DM category contains no channels, do not return DM category
 			if category.Type == model.SidebarCategoryDirectMessages && len(category.Channels) == 0 {
 				continue
 			}

--- a/server/channels/app/channel_category.go
+++ b/server/channels/app/channel_category.go
@@ -47,8 +47,6 @@ func (a *App) GetSidebarCategoriesForTeamForUser(c request.CTX, userID, teamID s
 		}
 	}
 
-	a.filterSidebarCategories(c, categories)
-
 	return categories, nil
 }
 

--- a/server/channels/app/channel_category_filter.go
+++ b/server/channels/app/channel_category_filter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
-func (a *App) filterSidebarCategories(c request.CTX, categories *model.OrderedSidebarCategories) {
+func (a *App) FilterSidebarCategories(c request.CTX, categories *model.OrderedSidebarCategories) {
 	session := c.Session()
 
 	if session.Roles == "" {

--- a/server/channels/app/channel_category_filter.go
+++ b/server/channels/app/channel_category_filter.go
@@ -11,7 +11,6 @@ import (
 func (a *App) filterSidebarCategories(c request.CTX, categories *model.OrderedSidebarCategories) {
 	session := c.Session()
 
-	// for testuser
 	if session.Roles == "" {
 		return
 	}
@@ -23,8 +22,8 @@ func (a *App) filterSidebarCategories(c request.CTX, categories *model.OrderedSi
 		return
 	}
 
-	filteredCategories := make(model.SidebarCategoriesWithChannels, 0)
-	filteredOrder := make(model.SidebarCategoryOrder, 0)
+	filteredCategories := make(model.SidebarCategoriesWithChannels, 0, len(categories.Categories))
+	filteredOrder := make(model.SidebarCategoryOrder, 0, len(categories.Order))
 
 	for _, category := range categories.Categories {
 		// When the user lacks permissions to create DMGM and DM category is empty, remove DM category

--- a/server/channels/app/channel_category_filter.go
+++ b/server/channels/app/channel_category_filter.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+)
+
+func (a *App) filterSidebarCategories(c request.CTX, categories *model.OrderedSidebarCategories) {
+	session := c.Session()
+
+	// for testuser
+	if session.Roles == "" {
+		return
+	}
+
+	canCreateDirectChannel := a.SessionHasPermissionTo(*session, model.PermissionCreateDirectChannel)
+	canCreateGroupChannel := a.SessionHasPermissionTo(*session, model.PermissionCreateGroupChannel)
+
+	if canCreateDirectChannel || canCreateGroupChannel {
+		return
+	}
+
+	filteredCategories := make(model.SidebarCategoriesWithChannels, 0)
+	filteredOrder := make(model.SidebarCategoryOrder, 0)
+
+	for _, category := range categories.Categories {
+		// When the user lacks permissions to create DMGM and DM category is empty, remove DM category
+		if category.Type == model.SidebarCategoryDirectMessages && len(category.Channels) == 0 {
+			continue
+		}
+		filteredCategories = append(filteredCategories, category)
+		filteredOrder = append(filteredOrder, category.Id)
+	}
+
+	categories.Categories = filteredCategories
+	categories.Order = filteredOrder
+}

--- a/server/channels/app/channel_category_filter_test.go
+++ b/server/channels/app/channel_category_filter_test.go
@@ -32,7 +32,7 @@ func TestFilterSidebarCategories(t *testing.T) {
 			},
 		}
 
-		th.App.filterSidebarCategories(ctx, categories)
+		th.App.FilterSidebarCategories(ctx, categories)
 		require.Len(t, categories.Categories, 1)
 	})
 
@@ -58,7 +58,7 @@ func TestFilterSidebarCategories(t *testing.T) {
 			},
 		}
 
-		th.App.filterSidebarCategories(ctx, categories)
+		th.App.FilterSidebarCategories(ctx, categories)
 		require.Len(t, categories.Categories, 0)
 	})
 
@@ -84,7 +84,7 @@ func TestFilterSidebarCategories(t *testing.T) {
 			},
 		}
 
-		th.App.filterSidebarCategories(ctx, categories)
+		th.App.FilterSidebarCategories(ctx, categories)
 		require.Len(t, categories.Categories, 1)
 	})
 
@@ -106,7 +106,7 @@ func TestFilterSidebarCategories(t *testing.T) {
 			},
 		}
 
-		th.App.filterSidebarCategories(ctx, categories)
+		th.App.FilterSidebarCategories(ctx, categories)
 		require.Len(t, categories.Categories, 1)
 	})
 }

--- a/server/channels/app/channel_category_filter_test.go
+++ b/server/channels/app/channel_category_filter_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+func TestFilterSidebarCategories(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	t.Run("user with DM permissions should not filter", func(t *testing.T) {
+		session := &model.Session{
+			Roles: model.SystemUserRoleId,
+		}
+		ctx := th.Context.WithSession(session)
+
+		categories := &model.OrderedSidebarCategories{
+			Categories: model.SidebarCategoriesWithChannels{
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type: model.SidebarCategoryDirectMessages,
+					},
+					Channels: []string{}, // empty DM category
+				},
+			},
+		}
+
+		th.App.filterSidebarCategories(ctx, categories)
+		require.Len(t, categories.Categories, 1)
+	})
+
+	t.Run("user without DM permissions and empty DM category should filter", func(t *testing.T) {
+		th.RemovePermissionFromRole(model.PermissionCreateDirectChannel.Id, model.SystemUserRoleId)
+		th.RemovePermissionFromRole(model.PermissionCreateGroupChannel.Id, model.SystemUserRoleId)
+		defer th.AddPermissionToRole(model.PermissionCreateDirectChannel.Id, model.SystemUserRoleId)
+		defer th.AddPermissionToRole(model.PermissionCreateGroupChannel.Id, model.SystemUserRoleId)
+
+		session := &model.Session{
+			Roles: model.SystemUserRoleId,
+		}
+		ctx := th.Context.WithSession(session)
+
+		categories := &model.OrderedSidebarCategories{
+			Categories: model.SidebarCategoriesWithChannels{
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type: model.SidebarCategoryDirectMessages,
+					},
+					Channels: []string{}, // empty DM category
+				},
+			},
+		}
+
+		th.App.filterSidebarCategories(ctx, categories)
+		require.Len(t, categories.Categories, 0)
+	})
+
+	t.Run("user without DM permissions and have DM category should not filter", func(t *testing.T) {
+		th.RemovePermissionFromRole(model.PermissionCreateDirectChannel.Id, model.SystemUserRoleId)
+		th.RemovePermissionFromRole(model.PermissionCreateGroupChannel.Id, model.SystemUserRoleId)
+		defer th.AddPermissionToRole(model.PermissionCreateDirectChannel.Id, model.SystemUserRoleId)
+		defer th.AddPermissionToRole(model.PermissionCreateGroupChannel.Id, model.SystemUserRoleId)
+
+		session := &model.Session{
+			Roles: model.SystemUserRoleId,
+		}
+		ctx := th.Context.WithSession(session)
+
+		categories := &model.OrderedSidebarCategories{
+			Categories: model.SidebarCategoriesWithChannels{
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type: model.SidebarCategoryDirectMessages,
+					},
+					Channels: []string{th.BasicChannel.Id},
+				},
+			},
+		}
+
+		th.App.filterSidebarCategories(ctx, categories)
+		require.Len(t, categories.Categories, 1)
+	})
+
+	t.Run("test user with empty roles should not filter", func(t *testing.T) {
+		session := &model.Session{
+			UserId: th.BasicUser.Id,
+			Roles:  "",
+		}
+		ctx := th.Context.WithSession(session)
+
+		originalCategories := &model.OrderedSidebarCategories{
+			Categories: model.SidebarCategoriesWithChannels{
+				{
+					SidebarCategory: model.SidebarCategory{
+						Type: model.SidebarCategoryDirectMessages,
+					},
+					Channels: []string{}, // empty DM category
+				},
+			},
+		}
+
+		th.App.filterSidebarCategories(ctx, originalCategories)
+		require.Len(t, originalCategories.Categories, 1)
+	})
+}

--- a/server/channels/app/channel_category_filter_test.go
+++ b/server/channels/app/channel_category_filter_test.go
@@ -95,7 +95,7 @@ func TestFilterSidebarCategories(t *testing.T) {
 		}
 		ctx := th.Context.WithSession(session)
 
-		originalCategories := &model.OrderedSidebarCategories{
+		categories := &model.OrderedSidebarCategories{
 			Categories: model.SidebarCategoriesWithChannels{
 				{
 					SidebarCategory: model.SidebarCategory{
@@ -106,7 +106,7 @@ func TestFilterSidebarCategories(t *testing.T) {
 			},
 		}
 
-		th.App.filterSidebarCategories(ctx, originalCategories)
-		require.Len(t, originalCategories.Categories, 1)
+		th.App.filterSidebarCategories(ctx, categories)
+		require.Len(t, categories.Categories, 1)
 	})
 }


### PR DESCRIPTION
Remove DM Category when DMGM is not allowed for user.

## Background 
- https://github.com/stmninc/tunag-chat/issues/499

## Feature
- Hide DM category,
  - when user does not have permission to create DMGM &&
  - there are no channels in the DM category.

**Before**
<img width=30% alt="image" src="https://github.com/user-attachments/assets/2d7da7a5-e7ca-4356-8b41-9b82c312c7d7" />

**After**
<img width=30% alt="image" src="https://github.com/user-attachments/assets/73ee1dc0-33e8-42ce-b768-da87fb42bb74" />


## 実装の意図
元々App層でバリデーションを完結させる予定だったが、`GetSidebarCategoriesForTeamForUser`を呼んでいる別関数に影響を及ぼす可能性が高かった。そのため特定のAPIだけの対応になるように、バリデーションをAPI層に移動した。