### PR TITLE
feat: Prevent duplicate incoming call for same VoIP ID

### DIFF
--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -148,8 +148,8 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		)
 	}
 
-	// sentDeviceIDs tracks unique deviceIDs to prevent duplicate incoming call notifications
-	sentDeviceIDs := make(map[string]struct{})
+	// sentVoipDeviceIDs tracks unique VoipDeviceIDs to prevent duplicate incoming call notifications
+	sentVoipDeviceIDs := make(map[string]struct{})
 
 	for _, session := range sessions {
 		// Don't send notifications to this session if it's expired or we want to skip it
@@ -171,9 +171,11 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		if msg.SubType == model.PushSubTypeCalls && session.VoipDeviceId != "" {
 			deviceID = session.VoipDeviceId
 			// For incoming calls, ensure we only send once per VoIP deviceID
-			if _, exists := sentDeviceIDs[deviceID]; exists {
+			if _, exists := sentVoipDeviceIDs[deviceID]; exists {
 				continue
 			}
+			// Record the deviceID regardless of send success or failure
+			sentVoipDeviceIDs[deviceID] = struct{}{}
 		}
 		tmpMessage.SetDeviceIdAndPlatform(deviceID)
 		tmpMessage.AckId = model.NewId()
@@ -214,9 +216,6 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 			)
 			continue
 		}
-
-		// Record the deviceID as sent
-		sentDeviceIDs[deviceID] = struct{}{}
 
 		a.NotificationsLog().Trace("Notification sent to push proxy",
 			mlog.String("type", model.NotificationTypePush),

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -171,7 +171,7 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		if msg.SubType == model.PushSubTypeCalls && session.VoipDeviceId != "" {
 			deviceID = session.VoipDeviceId
 			// For incoming calls, ensure we only send once per VoIP deviceID
-			if _, exist := sentDeviceIDs[deviceID]; exist {
+			if _, exists := sentDeviceIDs[deviceID]; exists {
 				continue
 			}
 		}
@@ -216,7 +216,7 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		}
 
 		// Record the deviceID as sent
-		sentDeviceIDs[tmpMessage.DeviceId] = struct{}{}
+		sentDeviceIDs[deviceID] = struct{}{}
 
 		a.NotificationsLog().Trace("Notification sent to push proxy",
 			mlog.String("type", model.NotificationTypePush),

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -148,6 +148,9 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		)
 	}
 
+	// store already sent deviceIDs to prevent duplicate incomming call notifications
+	sentDeviceIDs := make(map[string]struct{})
+
 	for _, session := range sessions {
 		// Don't send notifications to this session if it's expired or we want to skip it
 		if session.IsExpired() || (skipSessionId != "" && skipSessionId == session.Id) {
@@ -167,6 +170,10 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		deviceID := session.DeviceId
 		if msg.SubType == model.PushSubTypeCalls && session.VoipDeviceId != "" {
 			deviceID = session.VoipDeviceId
+			// Check only incoming call where duplicate notification bug has been confirmed
+			if _, exist := sentDeviceIDs[deviceID]; exist {
+				continue
+			}
 		}
 		tmpMessage.SetDeviceIdAndPlatform(deviceID)
 		tmpMessage.AckId = model.NewId()
@@ -207,6 +214,8 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 			)
 			continue
 		}
+
+		sentDeviceIDs[tmpMessage.DeviceId] = struct{}{}
 
 		a.NotificationsLog().Trace("Notification sent to push proxy",
 			mlog.String("type", model.NotificationTypePush),

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -174,7 +174,7 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 			if _, exists := sentVoipDeviceIDs[deviceID]; exists {
 				continue
 			}
-			// Record the deviceID regardless of send success or failure
+			// Record the VoIP deviceID before attempting to send, preventing retries even if the send fails
 			sentVoipDeviceIDs[deviceID] = struct{}{}
 		}
 		tmpMessage.SetDeviceIdAndPlatform(deviceID)

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -148,7 +148,7 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		)
 	}
 
-	// store already sent deviceIDs to prevent duplicate incomming call notifications
+	// sentDeviceIDs tracks unique deviceIDs to prevent duplicate incoming call notifications
 	sentDeviceIDs := make(map[string]struct{})
 
 	for _, session := range sessions {
@@ -170,7 +170,7 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		deviceID := session.DeviceId
 		if msg.SubType == model.PushSubTypeCalls && session.VoipDeviceId != "" {
 			deviceID = session.VoipDeviceId
-			// Check only incoming call where duplicate notification bug has been confirmed
+			// For incoming calls, ensure we only send once per VoIP deviceID
 			if _, exist := sentDeviceIDs[deviceID]; exist {
 				continue
 			}
@@ -215,6 +215,7 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 			continue
 		}
 
+		// Record the deviceID as sent
 		sentDeviceIDs[tmpMessage.DeviceId] = struct{}{}
 
 		a.NotificationsLog().Trace("Notification sent to push proxy",

--- a/server/channels/app/notification_push_call_test.go
+++ b/server/channels/app/notification_push_call_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
+)
+
+func TestSendPushNotificationsForCall(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := SetupWithStoreMock(t)
+	defer th.TearDown()
+
+	mockStore := th.App.Srv().Store().(*mocks.Store)
+	mockUserStore := mocks.UserStore{}
+	mockUserStore.On("Count", mock.Anything).Return(int64(10), nil)
+	mockUserStore.On("GetUnreadCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return(int64(1), nil)
+	mockPostStore := mocks.PostStore{}
+	mockPostStore.On("GetMaxPostSize").Return(65535, nil)
+	mockSystemStore := mocks.SystemStore{}
+	mockSystemStore.On("GetByName", "UpgradedFromTE").Return(&model.System{Name: "UpgradedFromTE", Value: "false"}, nil)
+	mockSystemStore.On("GetByName", "InstallationDate").Return(&model.System{Name: "InstallationDate", Value: "10"}, nil)
+	mockSystemStore.On("GetByName", "FirstServerRunTimestamp").Return(&model.System{Name: "FirstServerRunTimestamp", Value: "10"}, nil)
+
+	mockSessionStore := mocks.SessionStore{}
+	mockPreferenceStore := mocks.PreferenceStore{}
+	mockPreferenceStore.On("Get", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.Preference{Value: "test"}, nil)
+	mockStore.On("User").Return(&mockUserStore)
+	mockStore.On("Post").Return(&mockPostStore)
+	mockStore.On("System").Return(&mockSystemStore)
+	mockStore.On("Session").Return(&mockSessionStore)
+	mockStore.On("Preference").Return(&mockPreferenceStore)
+	mockStore.On("GetDBSchemaVersion").Return(1, nil)
+
+	// Start mock push proxy server & set proxy server url
+	handler := &testPushNotificationHandler{
+		t:        t,
+		behavior: "simple",
+	}
+	mockPushServer := httptest.NewServer(http.HandlerFunc(handler.handleReq))
+	defer mockPushServer.Close()
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.EmailSettings.PushNotificationServer = mockPushServer.URL
+	})
+
+	userID := model.NewId()
+	sessions := []*model.Session{
+		{
+			Id:           "sess1",
+			UserId:       userID,
+			DeviceId:     "apple:device1",
+			VoipDeviceId: "voip:123",
+			ExpiresAt:    model.GetMillis() + 100000000, // Active
+		},
+		{
+			Id:           "sess2",
+			UserId:       userID,
+			DeviceId:     "apple:device2",
+			VoipDeviceId: "voip:123",                    // Same as session1, should be skipped
+			ExpiresAt:    model.GetMillis() + 100000000, // Active
+		},
+		{
+			Id:           "sess3",
+			UserId:       userID,
+			DeviceId:     "apple:device3",
+			VoipDeviceId: "voip:123",                    // Same as session1, should be skipped
+			ExpiresAt:    model.GetMillis() + 100000000, // Active
+		},
+		{
+			Id:           "sess4",
+			UserId:       userID,
+			DeviceId:     "apple:device4",
+			VoipDeviceId: "voip:456",
+			ExpiresAt:    model.GetMillis() + 100000000, // Active
+		},
+	}
+
+	notification := &model.PushNotification{
+		Type:    model.PushTypeMessage,
+		SubType: model.PushSubTypeCalls,
+	}
+
+	mockSessionStore.On("GetSessionsWithActiveDeviceIds", userID).Return(sessions, nil)
+	mockStore.On("Session").Return(&mockSessionStore)
+
+	err := th.App.sendPushNotificationToAllSessions(th.Context, notification, userID, "")
+	require.Nil(t, err)
+
+	// for mockPushServer
+	time.Sleep(1 * time.Second)
+	// handler.numReqs() returns the total counts of http requests received by mockPushServer
+	assert.Equal(t, 2, handler.numReqs(), "The number of sessions that should send push notification does not match the actual number of requests")
+
+	mockSessionStore.AssertExpectations(t)
+}


### PR DESCRIPTION
### Background
- https://github.com/stmninc/tunag-chat/issues/460?issue=stmninc%7Ctunag-chat%7C692#:~:text=%E3%82%B1%E3%83%BC%E3%82%B9%E3%81%8C%E3%81%82%E3%82%8B-,%23692,-Edit

異なるSessionにおいてVoipDeviceIDが重複して登録される現象が確認されており、iOSの着信通知がモバイル側で重複してしまっていた。

### Feature

通知送信に成功した`DeviceID`を記録し、現在送信しようとしているDeviceIDが既に送信されたことがあるか確認する処理を追加した。
着信通知＆`VoipDeviceID`に対して送る場合にのみ、バリデーションを追加した。

VoipIDの重複自体を解決するものではない。本PRは応急措置としての対応となる。理由としては、
- 重複する原因が、既存実装によるものか、VoipIDの追加実装に関連するものかを切り分けることが難しいため
- また、確認されたユーザーがデバッグ環境で１人のみ・本番環境では再現していないため


### Verification
staging-stmnにて、PushProxyのURLをstaging-mattermost-push-proxyに設定した。
モバイルアプリはデバッグ版を使用し、過去にVoipIDの重複が確認された`tunag2099-100`ユーザー・同一端末において重複通知が解消されたことを確認した。