### PR TITLE
Feat/ Disable ID-PW fields in non-dev environments

### DIFF
--- a/webapp/channels/src/components/login/login.test.tsx
+++ b/webapp/channels/src/components/login/login.test.tsx
@@ -369,4 +369,32 @@ describe('components/login/Login', () => {
 
         expect(history.push).toHaveBeenCalledWith(redirectPath);
     });
+
+    it('should hide login form when server is not dev', () => {
+        const spy = jest.spyOn(require('utils/url'), 'isDevServer').mockReturnValue(false);
+
+        const state = mergeObjects(baseState, {
+            entities: {
+                general: {
+                    config: {
+                        EnableSignInWithEmail: 'true',
+                    },
+                },
+                users: {
+                    currentUserId: 'user1',
+                },
+            },
+        });
+
+        renderWithContext(
+            <Login/>,
+            state,
+        );
+
+        expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'Log in'})).not.toBeInTheDocument();
+
+        spy.mockRestore();
+    });
 });

--- a/webapp/channels/src/components/login/login.tsx
+++ b/webapp/channels/src/components/login/login.tsx
@@ -51,6 +51,7 @@ import DesktopApp from 'utils/desktop_api';
 import {isEmbedded} from 'utils/embed';
 import {t} from 'utils/i18n';
 import {showNotification} from 'utils/notifications';
+import {getSiteURL, isDevServer} from 'utils/url';
 import {isDesktopApp} from 'utils/user_agent';
 import {setCSRFFromCookie} from 'utils/utils';
 
@@ -140,10 +141,15 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
     const enableSignUpWithSaml = isLicensed && enableSaml;
     const siteName = SiteName ?? '';
 
-    const enableBaseLogin = enableSignInWithEmail || enableSignInWithUsername || ldapEnabled;
+    let enableBaseLogin = enableSignInWithEmail || enableSignInWithUsername || ldapEnabled;
     const enableExternalSignup = enableSignUpWithGitLab || enableSignUpWithOffice365 || enableSignUpWithGoogle || enableSignUpWithOpenId || enableSignUpWithSaml;
     const showSignup = enableOpenServer && (enableExternalSignup || enableSignUpWithEmail || enableLdap);
     const onlyLdapEnabled = enableLdap && !(enableSaml || enableSignInWithEmail || enableSignInWithUsername || enableSignUpWithEmail || enableSignUpWithGitLab || enableSignUpWithGoogle || enableSignUpWithOffice365 || enableSignUpWithOpenId);
+
+    // Disable ID/PW login in non-dev server
+    if (!isDevServer(getSiteURL())) {
+        enableBaseLogin = false;
+    }
 
     const query = new URLSearchParams(search);
     const redirectTo = query.get('redirect_to');

--- a/webapp/channels/src/utils/url.test.tsx
+++ b/webapp/channels/src/utils/url.test.tsx
@@ -7,6 +7,7 @@ import {
     getSiteURLFromWindowObject,
     isPermalinkURL,
     validateChannelUrl,
+    isDevServer,
 } from 'utils/url';
 
 describe('Utils.URL', () => {
@@ -131,6 +132,18 @@ describe('Utils.URL', () => {
             ['https://example.com/teamname-1/pl/affe2344234', false],
         ])('is permalink for %s should return %s', (url, expected) => {
             expect(isPermalinkURL(url)).toBe(expected);
+        });
+    });
+
+    describe('isDevServer', () => {
+        test.each([
+            [true, 'http://localhost:8065'],
+            [true, 'http://localhost:8065/some/path'],
+
+            [false, 'https://example.com'],
+            [false, 'https://example.jp'],
+        ])('should return %s for %s', (expected, url) => {
+            expect(isDevServer(url)).toBe(expected);
         });
     });
 });

--- a/webapp/channels/src/utils/url.tsx
+++ b/webapp/channels/src/utils/url.tsx
@@ -371,3 +371,9 @@ export const validHttpUrl = (input: string) => {
 
     return url;
 };
+
+export function isDevServer(serverURL: string): boolean {
+    const serverHost = new URL(serverURL).hostname;
+
+    return serverHost === 'localhost';
+}


### PR DESCRIPTION
## Background
- issue:none

## Feature
- 開発環境でない時、ログインフォームのID\PWの入力欄を非表示にする。
- 開発環境のURLはハードコードしており、Localhostも含めている。

localhostでの開発時
<img width="1470" height="665" alt="image" src="https://github.com/user-attachments/assets/3e634bbf-9a36-42ba-9c35-c08c52f54461" />


開発環境以外・Gitlab:enable
<img width="1470" height="652" alt="image" src="https://github.com/user-attachments/assets/2a4f5642-2d52-4075-ba90-8ec23d49eba6" />

開発環境以外・Gitlab:disable
<img width="1470" height="658" alt="image" src="https://github.com/user-attachments/assets/19bb7405-d93f-49f5-9013-079b573dc1f7" />
