### PR TITLE
fix: reduce cpu usage by uploading files

### DIFF
--- a/server/channels/api4/file.go
+++ b/server/channels/api4/file.go
@@ -32,7 +32,7 @@ const (
 const maxMultipartFormDataBytes = 10 * 1024 // 10Kb
 
 func (api *API) InitFile() {
-	api.BaseRoutes.Files.Handle("", api.APISessionRequired(uploadFile, handlerParamFileAPI)).Methods(http.MethodPost)
+	api.BaseRoutes.Files.Handle("", api.APISessionRequired(uploadFileStream, handlerParamFileAPI)).Methods(http.MethodPost)
 	api.BaseRoutes.File.Handle("", api.APISessionRequiredTrustRequester(getFile)).Methods(http.MethodGet)
 	api.BaseRoutes.File.Handle("/thumbnail", api.APISessionRequiredTrustRequester(getFileThumbnail)).Methods(http.MethodGet)
 	api.BaseRoutes.File.Handle("/link", api.APISessionRequired(getFileLink)).Methods(http.MethodGet)
@@ -46,7 +46,9 @@ func (api *API) InitFile() {
 }
 
 func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
-	defer io.Copy(io.Discard, r.Body)
+	defer func() {
+		_, _ = io.Copy(io.Discard, r.Body)
+	}()
 
 	if !*c.App.Config().FileSettings.EnableFileAttachments {
 		c.Err = model.NewAppError("uploadFile", "api.file.attachments.disabled.app_error", nil, "", http.StatusNotImplemented)
@@ -161,7 +163,6 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Logger.Warn("Error while writing response", mlog.Err(err))
 		}
 	}
-
 }
 
 func parseMultipartRequestHeader(req *http.Request) (boundary string, err error) {
@@ -195,6 +196,11 @@ func multipartReader(req *http.Request, stream io.Reader) (*multipart.Reader, er
 }
 
 func uploadFileStream(c *Context, w http.ResponseWriter, r *http.Request) {
+	if true {
+		// avoid to use stream upload
+		uploadFile(c, w, r)
+	}
+
 	if !*c.App.Config().FileSettings.EnableFileAttachments {
 		c.Err = model.NewAppError("uploadFileStream",
 			"api.file.attachments.disabled.app_error",

--- a/server/channels/api4/file.go
+++ b/server/channels/api4/file.go
@@ -32,7 +32,7 @@ const (
 const maxMultipartFormDataBytes = 10 * 1024 // 10Kb
 
 func (api *API) InitFile() {
-	api.BaseRoutes.Files.Handle("", api.APISessionRequired(uploadFileStream, handlerParamFileAPI)).Methods(http.MethodPost)
+	api.BaseRoutes.Files.Handle("", api.APISessionRequired(uploadFile, handlerParamFileAPI)).Methods(http.MethodPost)
 	api.BaseRoutes.File.Handle("", api.APISessionRequiredTrustRequester(getFile)).Methods(http.MethodGet)
 	api.BaseRoutes.File.Handle("/thumbnail", api.APISessionRequiredTrustRequester(getFileThumbnail)).Methods(http.MethodGet)
 	api.BaseRoutes.File.Handle("/link", api.APISessionRequired(getFileLink)).Methods(http.MethodGet)
@@ -43,6 +43,125 @@ func (api *API) InitFile() {
 	api.BaseRoutes.Files.Handle("/search", api.APISessionRequiredDisableWhenBusy(searchFilesInAllTeams)).Methods(http.MethodPost)
 
 	api.BaseRoutes.PublicFile.Handle("", api.APIHandler(getPublicFile)).Methods(http.MethodGet, http.MethodHead)
+}
+
+func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
+	defer io.Copy(io.Discard, r.Body)
+
+	if !*c.App.Config().FileSettings.EnableFileAttachments {
+		c.Err = model.NewAppError("uploadFile", "api.file.attachments.disabled.app_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
+	if r.ContentLength > *c.App.Config().FileSettings.MaxFileSize {
+		c.Err = model.NewAppError("uploadFile", "api.file.upload_file.too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	var resStruct *model.FileUploadResponse
+
+	if err := r.ParseMultipartForm(*c.App.Config().FileSettings.MaxFileSize); err != nil && err != http.ErrNotMultipart {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	} else if err == http.ErrNotMultipart {
+		defer r.Body.Close()
+
+		c.RequireChannelId()
+		c.RequireFilename()
+
+		if c.Err != nil {
+			return
+		}
+
+		channelId := c.Params.ChannelId
+		filename := c.Params.Filename
+
+		if !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channelId, model.PermissionUploadFile) {
+			c.SetPermissionError(model.PermissionUploadFile)
+			return
+		}
+
+		resStruct, appErr := c.App.UploadFileX(c.AppContext, c.Params.ChannelId, filename, r.Body,
+			app.UploadFileSetTeamId(FileTeamId),
+			app.UploadFileSetUserId(c.AppContext.Session().UserId),
+			app.UploadFileSetTimestamp(time.Now()),
+			app.UploadFileSetContentLength(-1),
+			app.UploadFileSetClientId(""))
+
+		if appErr != nil {
+			c.Err = appErr
+			return
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(resStruct); err != nil {
+			c.Logger.Warn("Error while writing response", mlog.Err(err))
+		}
+	} else {
+		m := r.MultipartForm
+
+		props := m.Value
+		if len(props["channel_id"]) == 0 {
+			c.SetInvalidParam("channel_id")
+			return
+		}
+		channelId := props["channel_id"][0]
+		if len(channelId) == 0 {
+			c.SetInvalidParam("channel_id")
+			return
+		}
+
+		if !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), channelId, model.PermissionUploadFile) {
+			c.SetPermissionError(model.PermissionUploadFile)
+			return
+		}
+
+		resStruct = &model.FileUploadResponse{
+			FileInfos: []*model.FileInfo{},
+			ClientIds: []string{},
+		}
+
+		clientIds := props["client_ids"]
+		fileHeaders := m.File["files"]
+
+		for i, fileHeader := range fileHeaders {
+			f, err := fileHeader.Open()
+			if err != nil {
+				c.Err = model.NewAppError("uploadFile", "api.file.read_request.app_error", nil, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			clientId := ""
+			if len(clientIds) > i {
+				clientId = clientIds[i]
+			}
+
+			res, appErr := c.App.UploadFileX(c.AppContext, channelId, fileHeader.Filename, f,
+				app.UploadFileSetTeamId(FileTeamId),
+				app.UploadFileSetUserId(c.AppContext.Session().UserId),
+				app.UploadFileSetTimestamp(time.Now()),
+				app.UploadFileSetContentLength(-1),
+				app.UploadFileSetClientId(clientId))
+			f.Close()
+
+			if appErr != nil {
+				c.Err = appErr
+				return
+			}
+
+			resStruct.FileInfos = append(resStruct.FileInfos, res)
+			if clientId != "" {
+				resStruct.ClientIds = append(resStruct.ClientIds, clientId)
+			}
+		}
+
+		w.Header().Set("X-Debug-Path", "ALIVE-AND-PASSING-NEW-FUNC")
+		w.WriteHeader(http.StatusCreated)
+		if err := json.NewEncoder(w).Encode(resStruct); err != nil {
+			c.Logger.Warn("Error while writing response", mlog.Err(err))
+		}
+	}
+
 }
 
 func parseMultipartRequestHeader(req *http.Request) (boundary string, err error) {


### PR DESCRIPTION
## background
- https://github.com/stmninc/tunag-chat/issues/734
このIssueにおいて、FileアップロードによりCPU負荷がスパイクすることが確認された。
これを解消したい。

## feature
ファイルをBufferingする処理を削除し、一括でファイルを読み込むようにした。

#### feature Intention
- 7年前Streamで処理するように変更されたファイルアップロード方式が、一括で読み込む処理に変更された。
https://github.com/mattermost/mattermost/pull/9835
- Stream処理はメモリ消費量を少なくする目的で導入されたが、その代償としてBufferで確保しているメモリの処理によりCPU負荷が上がっている可能性がある。

この変更によりどのくらいCPU負荷が下がり、メモリ使用量が上がるのかを検証したい。

## verification
