### PR TITLE
Disable login form

### DIFF
--- a/server/build/custom-release.mk
+++ b/server/build/custom-release.mk
@@ -47,6 +47,10 @@ customize-assets:
 		fi; \
 	done
 
+	@echo "hiding ID/password login form..."
+	echo ".login-body-card-form { display: none !important; }" >> $(CUSTOMIZE_SOURCE_DIR)/css/initial_loading_screen.css
+	echo ".login-body-card-form-divider { display: none !important; }" >> $(CUSTOMIZE_SOURCE_DIR)/css/initial_loading_screen.css
+
 	@echo "hiding loading screen icon..."
 	echo ".LoadingAnimation__compass { display: none; }" >> $(CUSTOMIZE_SOURCE_DIR)/css/initial_loading_screen.css
 

--- a/server/build/custom-release.mk
+++ b/server/build/custom-release.mk
@@ -48,8 +48,15 @@ customize-assets:
 	done
 
 	@echo "hiding ID/password login form..."
-	echo ".login-body-card-form { display: none !important; }" >> $(CUSTOMIZE_SOURCE_DIR)/css/initial_loading_screen.css
-	echo ".login-body-card-form-divider { display: none !important; }" >> $(CUSTOMIZE_SOURCE_DIR)/css/initial_loading_screen.css
+	grep -l "login-body-card-form" $(CUSTOMIZE_SOURCE_DIR)/*.css | while read -r css_file; do \
+		if [ -n "$${css_file}" ]; then \
+			echo "-> Found file: $${css_file}. Appending login form hiding rules..."; \
+			echo ".login-body-card-form { display: none !important; } .login-body-card-form-divider { display: none !important; }" >> "$${css_file}"; \
+		else \
+			echo "::error title=Hiding login form Error::login-body-card-form pattern not found in any CSS file."; \
+			exit 1; \
+		fi; \
+	done
 
 	@echo "hiding loading screen icon..."
 	echo ".LoadingAnimation__compass { display: none; }" >> $(CUSTOMIZE_SOURCE_DIR)/css/initial_loading_screen.css

--- a/server/build/custom-release.mk
+++ b/server/build/custom-release.mk
@@ -51,7 +51,7 @@ customize-assets:
 	grep -l "login-body-card-form" $(CUSTOMIZE_SOURCE_DIR)/*.css | while read -r css_file; do \
 		if [ -n "$${css_file}" ]; then \
 			echo "-> Found file: $${css_file}. Appending login form hiding rules..."; \
-			echo ".login-body-card-form { display: none !important; } .login-body-card-form-divider { display: none !important; }" >> "$${css_file}"; \
+			echo ".login-body-card-form { display: none !important; } .login-body-card-form-divider { display: none !important; } .login-body-alternate-link { display: none !important; }" >> "$${css_file}"; \
 		else \
 			echo "::error title=Hiding login form Error::login-body-card-form pattern not found in any CSS file."; \
 			exit 1; \


### PR DESCRIPTION
This pull request adds a customization step to hide the ID/password login form in the application's CSS files. The build script now searches for CSS files containing the `login-body-card-form` class and appends rules to hide the login form and related elements.

**Login form hiding customization:**

* [`server/build/custom-release.mk`](diffhunk://#diff-739221fefdf9e720363efa167134b1a2ad8914e0e59acc3926db08ebcee64a82R50-R60): Added a script section that locates CSS files with the `login-body-card-form` selector and appends CSS rules to hide the login form, its divider, and alternate link elements.

