### PR TITLE
fix: emit websocket event on role update to refresh FE state immediately

### DIFF
--- a/server/channels/api4/engage_chat_test.go
+++ b/server/channels/api4/engage_chat_test.go
@@ -25,6 +25,51 @@ func TestEnableCustomRoles(t *testing.T) {
 		CheckForbiddenStatus(t, resp)
 	})
 
+	t.Run("websocket event on role creation", func(t *testing.T) {
+		webSocketClient := th.CreateConnectedWebSocketClient(t)
+
+		// Create role
+		_, resp, err := th.SystemAdminClient.EnableCustomRoles(context.Background(), []string{model.SystemEngageAdmin})
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		assertExpectedWebsocketEvent(t, webSocketClient, model.WebsocketEventRoleUpdated, func(event *model.WebSocketEvent) {
+			roleStr, ok := event.GetData()["role"].(string)
+			require.True(t, ok, "expected role string")
+			assert.Contains(t, roleStr, model.SystemEngageAdmin)
+		})
+	})
+
+	t.Run("websocket event on role restoration", func(t *testing.T) {
+		webSocketClient := th.CreateConnectedWebSocketClient(t)
+
+		// Ensure the role exists first
+		_, resp, err := th.SystemAdminClient.EnableCustomRoles(context.Background(), []string{model.TeamEngageAdmin})
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		// Flush the creation event so it doesn't interfere
+		assertExpectedWebsocketEvent(t, webSocketClient, model.WebsocketEventRoleUpdated, func(event *model.WebSocketEvent) {})
+
+		// Soft-delete the role
+		role, err2 := th.App.GetRoleByName(context.Background(), model.TeamEngageAdmin)
+		require.Nil(t, err2)
+		_, err2 = th.App.DeleteRole(role.Id)
+		require.Nil(t, err2)
+
+		// Restore the role
+		_, resp, err = th.SystemAdminClient.EnableCustomRoles(context.Background(), []string{model.TeamEngageAdmin})
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		// Verify restoration event
+		assertExpectedWebsocketEvent(t, webSocketClient, model.WebsocketEventRoleUpdated, func(event *model.WebSocketEvent) {
+			roleStr, ok := event.GetData()["role"].(string)
+			require.True(t, ok, "expected role string")
+			assert.Contains(t, roleStr, model.TeamEngageAdmin)
+		})
+	})
+
 	t.Run("as admin user", func(t *testing.T) {
 		returnedRoles, resp, err := th.SystemAdminClient.EnableCustomRoles(context.Background(), roleNames)
 		require.NoError(t, err)

--- a/server/channels/app/engage_chat_role.go
+++ b/server/channels/app/engage_chat_role.go
@@ -66,6 +66,10 @@ func (a *App) createCustomRole(c request.CTX, role *model.Role) (*model.Role, *m
 		return nil, err
 	}
 
+	if appErr := a.sendUpdatedRoleEvent(role); appErr != nil {
+		return nil, appErr
+	}
+
 	c.Logger().Info("Created custom role for engage-chat",
 		mlog.String("role_id", role.Id),
 		mlog.String("rolename", role.Name),
@@ -83,6 +87,10 @@ func (a *App) restoreCustomRole(c request.CTX, role *model.Role) (*model.Role, *
 	role, err := a.UpdateRole(role)
 	if err != nil {
 		return nil, err
+	}
+
+	if appErr := a.sendUpdatedRoleEvent(role); appErr != nil {
+		return nil, appErr
 	}
 
 	c.Logger().Info("Restored custom role for engage-chat",


### PR DESCRIPTION
- https://github.com/stmninc/tunag-chat/issues/884