### PR TITLE
fix: reject conversion if channel is official

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -283,6 +283,8 @@ func updateChannelPrivacy(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditRec.AddEventPriorState(channel)
+
 	// engage-chat feature:
 	isOfficial, appErr := c.App.IsOfficialChannel(c.AppContext, channel)
 	if appErr != nil {
@@ -293,8 +295,6 @@ func updateChannelPrivacy(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = model.NewAppError("updateChannelPrivacy", "api.channel.official_channel.forbidden", nil, "", http.StatusForbidden)
 		return
 	}
-
-	auditRec.AddEventPriorState(channel)
 
 	if model.ChannelType(privacy) == model.ChannelTypeOpen {
 		if ok, _ := c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), c.Params.ChannelId, model.PermissionConvertPrivateChannelToPublic); !ok {

--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -283,6 +283,17 @@ func updateChannelPrivacy(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// engage-chat feature:
+	isOfficial, appErr := c.App.IsOfficialChannel(c.AppContext, channel)
+	if appErr != nil {
+		c.Err = appErr
+		return
+	}
+	if isOfficial {
+		c.Err = model.NewAppError("updateChannelPrivacy", "api.channel.official_channel.forbidden", nil, "", http.StatusForbidden)
+		return
+	}
+
 	auditRec.AddEventPriorState(channel)
 
 	if model.ChannelType(privacy) == model.ChannelTypeOpen {

--- a/server/channels/api4/channel_official_test.go
+++ b/server/channels/api4/channel_official_test.go
@@ -390,21 +390,21 @@ func TestOfficialChannelValidation(t *testing.T) {
 		// 1. Official Channel Privacy Update Restrictions (Should fail)
 		// 1-a. System admin trying to change official channel privacy
 		_, resp, err := th.SystemAdminClient.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)
-		assert.Error(t, err)
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
 
 		// 1-b. Regular user trying to change official channel privacy
 		th.LoginBasic()
 		_, resp, err = th.Client.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)
-		assert.Error(t, err)
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
 
 		// 1-c. Official admin trying to change official channel privacy
 		_, _, err = th.Client.Login(context.Background(), officialAdmin.Email, "Pa$$word11")
 		require.NoError(t, err)
 		_, resp, err = th.Client.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)
-		assert.Error(t, err)
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
 
 		// 2. Regular Channel Privacy Update (Should succeed)
 		// 2-a. System admin trying to change regular channel privacy

--- a/server/channels/api4/channel_official_test.go
+++ b/server/channels/api4/channel_official_test.go
@@ -383,22 +383,36 @@ func TestOfficialChannelValidation(t *testing.T) {
 	})
 
 	t.Run("updateChannelPrivacy - Official Channel Restriction", func(t *testing.T) {
-		// 1. Official admin cannot change the privacy of an official channel
-		_, _, err := th.Client.Login(context.Background(), officialAdmin.Email, "Pa$$word11")
-		require.NoError(t, err)
+		// Grant permissions for regular users to convert channel privacy
+		th.AddPermissionToRole(model.PermissionConvertPublicChannelToPrivate.Id, model.SystemUserRoleId)
+		th.AddPermissionToRole(model.PermissionConvertPrivateChannelToPublic.Id, model.SystemUserRoleId)
 
-		_, resp, err := th.Client.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)
+		// 1. Official Channel Privacy Update Restrictions (Should fail)
+		// 1-a. System admin trying to change official channel privacy
+		_, resp, err := th.SystemAdminClient.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)
 		assert.Error(t, err)
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
-		// 2. Regular user cannot change the privacy of an official channel
+		// 1-b. Regular user trying to change official channel privacy
 		th.LoginBasic()
 		_, resp, err = th.Client.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)
 		assert.Error(t, err)
 		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 
-		// 3. Regular channel privacy can be updated normally
+		// 1-c. Official admin trying to change official channel privacy
+		_, _, err = th.Client.Login(context.Background(), officialAdmin.Email, "Pa$$word11")
+		require.NoError(t, err)
+		_, resp, err = th.Client.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+		// 2. Regular Channel Privacy Update (Should succeed)
+		// 2-a. System admin trying to change regular channel privacy
 		_, _, err = th.SystemAdminClient.UpdateChannelPrivacy(context.Background(), regularChannel.Id, model.ChannelTypePrivate)
+		assert.NoError(t, err)
+
+		// 2-b. System admin trying to change regular channel privacy back to public
+		_, _, err = th.SystemAdminClient.UpdateChannelPrivacy(context.Background(), regularChannel.Id, model.ChannelTypeOpen)
 		assert.NoError(t, err)
 	})
 }

--- a/server/channels/api4/channel_official_test.go
+++ b/server/channels/api4/channel_official_test.go
@@ -32,7 +32,7 @@ func TestOfficialChannelValidation(t *testing.T) {
 	// Create official admin user
 	officialAdmin := th.CreateUser()
 	officialAdmin.Username = officialAdminUsername
-	var err error
+	var setupErr error
 	_, appErr := th.App.UpdateUser(th.Context, officialAdmin, false)
 	require.Nil(t, appErr)
 	_, _, appErr = th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, officialAdmin.Id, "")
@@ -43,16 +43,16 @@ func TestOfficialChannelValidation(t *testing.T) {
 	require.Nil(t, appErr)
 
 	// Create official channel (created by official admin)
-	_, _, err = th.Client.Login(context.Background(), officialAdmin.Email, "Pa$$word11")
-	require.NoError(t, err)
+	_, _, setupErr = th.Client.Login(context.Background(), officialAdmin.Email, "Pa$$word11")
+	require.NoError(t, setupErr)
 	officialChannel := &model.Channel{
 		DisplayName: "Official Test Channel",
 		Name:        "official-test-channel",
 		Type:        model.ChannelTypeOpen,
 		TeamId:      th.BasicTeam.Id,
 	}
-	officialChannel, _, err = th.Client.CreateChannel(context.Background(), officialChannel)
-	require.NoError(t, err)
+	officialChannel, _, setupErr = th.Client.CreateChannel(context.Background(), officialChannel)
+	require.NoError(t, setupErr)
 
 	// Create non-official channel (created by regular user)
 	th.LoginBasic()
@@ -62,8 +62,8 @@ func TestOfficialChannelValidation(t *testing.T) {
 		Type:        model.ChannelTypeOpen,
 		TeamId:      th.BasicTeam.Id,
 	}
-	regularChannel, _, err = th.Client.CreateChannel(context.Background(), regularChannel)
-	require.NoError(t, err)
+	regularChannel, _, setupErr = th.Client.CreateChannel(context.Background(), regularChannel)
+	require.NoError(t, setupErr)
 
 	t.Run("updateChannel - Official Channel Title Restriction", func(t *testing.T) {
 		// Debug: Check if channel is really official
@@ -82,7 +82,7 @@ func TestOfficialChannelValidation(t *testing.T) {
 		}
 
 		// Test 1: Official admin can update title
-		_, _, err = th.Client.Login(context.Background(), officialAdmin.Username, "Pa$$word11")
+		_, _, err := th.Client.Login(context.Background(), officialAdmin.Username, "Pa$$word11")
 		require.NoError(t, err)
 		updatedChannel := *officialChannel
 		updatedChannel.DisplayName = "Updated Official Title"
@@ -384,7 +384,7 @@ func TestOfficialChannelValidation(t *testing.T) {
 
 	t.Run("updateChannelPrivacy - Official Channel Restriction", func(t *testing.T) {
 		// 1. Official admin cannot change the privacy of an official channel
-		_, _, err = th.Client.Login(context.Background(), officialAdmin.Email, "Pa$$word11")
+		_, _, err := th.Client.Login(context.Background(), officialAdmin.Email, "Pa$$word11")
 		require.NoError(t, err)
 
 		_, resp, err := th.Client.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)

--- a/server/channels/api4/channel_official_test.go
+++ b/server/channels/api4/channel_official_test.go
@@ -286,7 +286,8 @@ func TestOfficialChannelValidation(t *testing.T) {
 		_, err = th.SystemAdminClient.UpdateChannelRoles(context.Background(), officialChannel.Id, testUser.Id, newRoles)
 		require.Error(t, err)
 		if appErr, ok := err.(*model.AppError); ok {
-			require.Equal(t, "api.channel.update_member_roles.official_channel.forbidden", appErr.Id)
+			require.Equal(t, "api.channel.official_channel.forbidden", appErr.Id)
+			require.Equal(t, http.StatusForbidden, appErr.StatusCode)
 		} else {
 			t.Fatalf("Expected AppError, got %T", err)
 		}
@@ -379,6 +380,26 @@ func TestOfficialChannelValidation(t *testing.T) {
 		updatedTemp.DisplayName = "Updated by regular user"
 		_, _, err = th.Client.UpdateChannel(context.Background(), &updatedTemp)
 		assert.NoError(t, err, "Should handle non-existent creator gracefully")
+	})
+
+	t.Run("updateChannelPrivacy - Official Channel Restriction", func(t *testing.T) {
+		// 1. Official admin cannot change the privacy of an official channel
+		_, _, err = th.Client.Login(context.Background(), officialAdmin.Email, "Pa$$word11")
+		require.NoError(t, err)
+
+		_, resp, err := th.Client.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+		// 2. Regular user cannot change the privacy of an official channel
+		th.LoginBasic()
+		_, resp, err = th.Client.UpdateChannelPrivacy(context.Background(), officialChannel.Id, model.ChannelTypePrivate)
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+		// 3. Regular channel privacy can be updated normally
+		_, _, err = th.SystemAdminClient.UpdateChannelPrivacy(context.Background(), regularChannel.Id, model.ChannelTypePrivate)
+		assert.NoError(t, err)
 	})
 }
 

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_info_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_info_tab.tsx
@@ -90,6 +90,9 @@ function ChannelSettingsInfoTab({
     // SaveChangesPanel state
     const [saveChangesPanelState, setSaveChangesPanelState] = useState<SaveChangesPanelState>();
 
+    // Compute official channel check locally
+    const isOfficial = isOfficialTunagChannel(channel);
+
     // Handler for channel name validation errors
     const handleChannelNameError = useCallback((isError: boolean, errorMessage?: string) => {
         setChannelNameError(errorMessage || '');
@@ -135,6 +138,11 @@ function ChannelSettingsInfoTab({
     }, [dispatch, shouldShowPreviewHeader]);
 
     const handleChannelTypeChange = (type: ChannelType) => {
+        // Official channels cannot change privacy
+        if (isOfficial) {
+            return;
+        }
+
         // engage-chat feature: Allow conversion if user has necessary permission
         if (channel.type === Constants.PRIVATE_CHANNEL && type === Constants.OPEN_CHANNEL && !canConvertToPublic) {
             return;
@@ -373,7 +381,7 @@ function ChannelSettingsInfoTab({
                 onErrorStateChange={handleChannelNameError}
                 urlError={internalUrlError}
                 currentUrl={channelUrl}
-                readOnly={!canManageChannelProperties || isOfficialTunagChannel(channel)}
+                readOnly={!canManageChannelProperties || isOfficial}
                 isEditingExistingChannel={true}
             />
 
@@ -386,12 +394,12 @@ function ChannelSettingsInfoTab({
                     description: formatMessage({id: 'channel_modal.type.public.description', defaultMessage: 'Anyone can join'}),
 
                     // engage-chat feature: enable public button if user has necessary permission
-                    disabled: !canConvertToPublic,
+                    disabled: isOfficial || !canConvertToPublic,
                 }}
                 privateButtonProps={{
                     title: formatMessage({id: 'channel_modal.type.private.title', defaultMessage: 'Private Channel'}),
                     description: formatMessage({id: 'channel_modal.type.private.description', defaultMessage: 'Only invited members'}),
-                    disabled: !canConvertToPrivate,
+                    disabled: isOfficial || !canConvertToPrivate,
                 }}
                 onChange={handleChannelTypeChange}
             />

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_info_tab_engage_chat.test.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_info_tab_engage_chat.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import type {ChannelType} from '@mattermost/types/channels';
 
 import {renderWithContext} from 'tests/react_testing_utils';
+import * as officialChannelUtils from 'utils/official_channel_utils';
 import {TestHelper} from 'utils/test_helper';
 
 import ChannelSettingsInfoTab from './channel_settings_info_tab';
@@ -203,5 +204,17 @@ describe('ChannelSettingsInfoTab Private to Public Conversion (Engage Chat)', ()
 
         // Verify error state is shown in the save panel
         expect(screen.getByText(/There are errors in the form above/)).toBeInTheDocument();
+    });
+
+    it('should disable privacy conversion buttons when the channel is official', () => {
+        const spy = jest.spyOn(officialChannelUtils, 'isOfficialTunagChannel').mockReturnValue(true);
+
+        renderWithContext(<ChannelSettingsInfoTab {...baseProps}/>);
+
+        // Both public and private buttons should be disabled for official channels
+        expect(screen.getByRole('button', {name: /Public Channel/})).toHaveClass('disabled');
+        expect(screen.getByRole('button', {name: /Private Channel/})).toHaveClass('disabled');
+
+        spy.mockRestore();
     });
 });


### PR DESCRIPTION
- https://github.com/stmninc/tunag-chat/issues/1078#issuecomment-4669334494
- https://github.com/engage-chat/mattermost/pull/190

- fix: test for `updateChannelMemberRoles - Official Channel Role Management` that failing due to previous change(https://github.com/engage-chat/mattermost/pull/179)
