### PR TITLE
fix: use useSelector in sidebar_base_channel

### DIFF
--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/index.ts
@@ -6,17 +6,10 @@ import type {ConnectedProps} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {Channel} from '@mattermost/types/channels';
-
 import {leaveChannel} from 'actions/views/channel';
 import {openModal} from 'actions/views/modals';
 
 import SidebarBaseChannel from './sidebar_base_channel';
-
-export type OwnProps = {
-    channel: Channel;
-    currentTeamName: string;
-}
 
 function mapDispatchToProps(dispatch: Dispatch) {
     return {

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/index.ts
@@ -8,6 +8,8 @@ import type {Dispatch} from 'redux';
 
 import type {Channel} from '@mattermost/types/channels';
 
+import {getChannel} from 'mattermost-redux/selectors/entities/channels'
+
 import {leaveChannel} from 'actions/views/channel';
 import {openModal} from 'actions/views/modals';
 
@@ -22,9 +24,11 @@ export type OwnProps = {
     currentTeamName: string;
 }
 
-function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
+function mapStateToProps(state: GlobalState, ownProps: OwnProps): {isOfficial?: boolean} {
+    const channel = getChannel(state, ownProps.channel.id) || ownProps.channel;
+
     return {
-        isOfficial: isOfficialTunagChannel(ownProps.channel, state),
+        isOfficial: isOfficialTunagChannel(channel, state),
     };
 }
 

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/index.ts
@@ -8,28 +8,14 @@ import type {Dispatch} from 'redux';
 
 import type {Channel} from '@mattermost/types/channels';
 
-import {getChannel} from 'mattermost-redux/selectors/entities/channels';
-
 import {leaveChannel} from 'actions/views/channel';
 import {openModal} from 'actions/views/modals';
-
-import {isOfficialTunagChannel} from 'utils/official_channel_utils';
-
-import type {GlobalState} from 'types/store';
 
 import SidebarBaseChannel from './sidebar_base_channel';
 
 export type OwnProps = {
     channel: Channel;
     currentTeamName: string;
-}
-
-function mapStateToProps(state: GlobalState, ownProps: OwnProps): {isOfficial?: boolean} {
-    const channel = getChannel(state, ownProps.channel.id) || ownProps.channel;
-
-    return {
-        isOfficial: isOfficialTunagChannel(channel, state),
-    };
 }
 
 function mapDispatchToProps(dispatch: Dispatch) {
@@ -41,7 +27,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-const connector = connect(mapStateToProps, mapDispatchToProps);
+const connector = connect(null, mapDispatchToProps);
 
 export type PropsFromRedux = ConnectedProps<typeof connector>;
 

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/index.ts
@@ -8,7 +8,7 @@ import type {Dispatch} from 'redux';
 
 import type {Channel} from '@mattermost/types/channels';
 
-import {getChannel} from 'mattermost-redux/selectors/entities/channels'
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {leaveChannel} from 'actions/views/channel';
 import {openModal} from 'actions/views/modals';

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
@@ -10,6 +10,29 @@ import type {ChannelType} from '@mattermost/types/channels';
 import SidebarBaseChannel from 'components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel';
 
 import {renderWithContext, userEvent} from 'tests/react_testing_utils';
+import * as officialChannelUtils from 'utils/official_channel_utils';
+
+const mockState = {
+    entities: {
+        channels: {
+            channels: {},
+        },
+    },
+};
+
+jest.mock('react-redux', () => {
+    const original = jest.requireActual('react-redux') as typeof import('react-redux');
+    return {
+        ...original,
+        useSelector: (selector: (state: any) => unknown, equalityFn?: any) => {
+            try {
+                return original.useSelector(selector, equalityFn);
+            } catch {
+                return selector(mockState);
+            }
+        },
+    };
+});
 
 describe('components/sidebar/sidebar_channel/sidebar_base_channel', () => {
     const baseProps = {
@@ -35,8 +58,11 @@ describe('components/sidebar/sidebar_channel/sidebar_base_channel', () => {
             leaveChannel: jest.fn(),
             openModal: jest.fn(),
         },
-        isOfficial: false,
     };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
 
     test('should match snapshot', () => {
         const wrapper = shallow(
@@ -63,12 +89,9 @@ describe('components/sidebar/sidebar_channel/sidebar_base_channel', () => {
     });
 
     test('should match snapshot when official channel', () => {
-        const props = {
-            ...baseProps,
-            isOfficial: true,
-        };
+        jest.spyOn(officialChannelUtils, 'isOfficialTunagChannel').mockReturnValue(true);
         const wrapper = shallow(
-            <SidebarBaseChannel {...props}/>,
+            <SidebarBaseChannel {...baseProps}/>,
         );
 
         expect(wrapper).toMatchSnapshot();

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.test.tsx
@@ -20,6 +20,10 @@ const mockState = {
     },
 };
 
+jest.mock('utils/official_channel_utils', () => ({
+    isOfficialTunagChannel: jest.fn(() => false),
+}));
+
 jest.mock('react-redux', () => {
     const original = jest.requireActual('react-redux') as typeof import('react-redux');
     return {
@@ -60,10 +64,6 @@ describe('components/sidebar/sidebar_channel/sidebar_base_channel', () => {
         },
     };
 
-    afterEach(() => {
-        jest.restoreAllMocks();
-    });
-
     test('should match snapshot', () => {
         const wrapper = shallow(
             <SidebarBaseChannel {...baseProps}/>,
@@ -89,7 +89,7 @@ describe('components/sidebar/sidebar_channel/sidebar_base_channel', () => {
     });
 
     test('should match snapshot when official channel', () => {
-        jest.spyOn(officialChannelUtils, 'isOfficialTunagChannel').mockReturnValue(true);
+        jest.spyOn(officialChannelUtils, 'isOfficialTunagChannel').mockReturnValueOnce(true);
         const wrapper = shallow(
             <SidebarBaseChannel {...baseProps}/>,
         );

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -18,7 +18,7 @@ import SidebarBaseChannelIcon from './sidebar_base_channel_icon';
 
 import type {PropsFromRedux} from './index';
 
-export interface Props extends PropsFromRedux {
+export interface Props extends Omit<PropsFromRedux, 'isOfficial'> {
     channel: Channel;
     currentTeamName: string;
 }
@@ -27,7 +27,7 @@ const SidebarBaseChannel = ({
     channel,
     currentTeamName,
     actions,
-    isOfficial,
+    isOfficial = false,
 }: Props) => {
     const intl = useIntl();
 

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -8,6 +8,7 @@ import {useSelector} from 'react-redux';
 import type {Channel} from '@mattermost/types/channels';
 
 import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {getUser} from 'mattermost-redux/selectors/entities/users';
 
 import {trackEvent} from 'actions/telemetry_actions';
 
@@ -23,6 +24,7 @@ import type {GlobalState} from 'types/store';
 import SidebarBaseChannelIcon from './sidebar_base_channel_icon';
 
 import type {PropsFromRedux} from './index';
+import { Visibility } from '@tanstack/react-table';
 
 export interface Props extends PropsFromRedux {
     channel: Channel;
@@ -55,19 +57,33 @@ const SidebarBaseChannel = ({
         channelLeaveHandler = handleLeavePrivateChannel;
     }
 
-    const isOfficial = useSelector((state: GlobalState) => {
+    const channelIconState = useSelector((state: GlobalState) => {
         const ch = getChannel(state, channel.id) ?? channel;
+        if (!ch || !ch.creator_id || ch.type === Constants.DM_CHANNEL || ch.type === Constants.GM_CHANNEL) {
+            return 'unofficial';
+        }
 
-        return isOfficialTunagChannel(ch, state);
+        const creator = getUser(state, ch.creator_id);
+        if (!creator || !creator.username) {
+            return 'pending';
+        }
+
+        return isOfficialTunagChannel(ch, state) ? 'official' : 'unofficial';
     });
 
-    const channelIcon = isOfficial ? (
-        <BuildingIcon/>
-    ) : (
-        <SidebarBaseChannelIcon
-            channelType={channel.type}
-        />
-    );
+    let channelIcon = null;
+    if (channelIconState === 'pending') {
+        const iconClass = channel.type === Constants.OPEN_CHANNEL ? 'icon-globe' : 'icon-lock-outline';
+        channelIcon = <i className={`icon ${iconClass}`} style={{visibility: 'hidden'}}/>;
+    } else if (channelIconState === 'official') {
+        channelIcon = <BuildingIcon/>;
+    } else if (channelIconState === 'unofficial') {
+        channelIcon = (
+            <SidebarBaseChannelIcon
+                channelType={channel.type}
+            />
+        );
+    }
 
     let ariaLabelPrefix;
     if (channel.type === Constants.OPEN_CHANNEL) {

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -58,7 +58,7 @@ const SidebarBaseChannel = ({
     const isOfficial = useSelector((state: GlobalState) => {
         const ch = getChannel(state, channel.id) ?? channel;
 
-        return isOfficialTunagChannel(ch);
+        return isOfficialTunagChannel(ch, state);
     });
 
     const channelIcon = isOfficial ? (

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -18,7 +18,7 @@ import SidebarBaseChannelIcon from './sidebar_base_channel_icon';
 
 import type {PropsFromRedux} from './index';
 
-export interface Props extends Omit<PropsFromRedux, 'isOfficial'> {
+export interface Props extends PropsFromRedux {
     channel: Channel;
     currentTeamName: string;
 }

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -1,10 +1,13 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback} from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {useIntl} from 'react-intl';
+import {shallowEqual, useSelector} from 'react-redux';
 
 import type {Channel} from '@mattermost/types/channels';
+
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {trackEvent} from 'actions/telemetry_actions';
 
@@ -13,6 +16,9 @@ import SidebarChannelLink from 'components/sidebar/sidebar_channel/sidebar_chann
 import BuildingIcon from 'components/widgets/icons/building_icon';
 
 import Constants, {ModalIdentifiers} from 'utils/constants';
+import {isOfficialTunagChannel} from 'utils/official_channel_utils';
+
+import type {GlobalState} from 'types/store';
 
 import SidebarBaseChannelIcon from './sidebar_base_channel_icon';
 
@@ -27,7 +33,6 @@ const SidebarBaseChannel = ({
     channel,
     currentTeamName,
     actions,
-    isOfficial = false,
 }: Props) => {
     const intl = useIntl();
 
@@ -49,6 +54,12 @@ const SidebarBaseChannel = ({
     } else if (channel.type === Constants.PRIVATE_CHANNEL) {
         channelLeaveHandler = handleLeavePrivateChannel;
     }
+
+    const isOfficial = useSelector((state: GlobalState) => {
+        const ch = getChannel(state, channel.id) ?? channel;
+
+        return isOfficialTunagChannel(ch);
+    });
 
     const channelIcon = isOfficial ? (
         <BuildingIcon/>

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback} from 'react';
 import {useIntl} from 'react-intl';
 import {shallowEqual, useSelector} from 'react-redux';
 

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_base_channel/sidebar_base_channel.tsx
@@ -3,7 +3,7 @@
 
 import React, {useCallback} from 'react';
 import {useIntl} from 'react-intl';
-import {shallowEqual, useSelector} from 'react-redux';
+import {useSelector} from 'react-redux';
 
 import type {Channel} from '@mattermost/types/channels';
 


### PR DESCRIPTION
- https://github.com/stmninc/tunag-chat/issues/1081#issuecomment-4798263013


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * チャンネルの「公式」判定を画面表示時の状態に合わせて見直し、アイコン表示がより正確になりました。
  * 判定中はプレースホルダーを表示し、公式チャンネルは専用アイコン、それ以外は通常アイコンを表示するようになりました。
  * 公式チャンネル表示のテストも更新され、表示の安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->